### PR TITLE
Fix hostname in nginx configuration template

### DIFF
--- a/templates/config/nginx/default.conf.mustache
+++ b/templates/config/nginx/default.conf.mustache
@@ -37,14 +37,14 @@ server {
 	location /redis-fetch {
 		internal  ;
 		set  $redis_key $args;
-		redis_pass  ee_redis:6379;
+		redis_pass  redis:6379;
 	}
 	location /redis-store {
 		internal  ;
 		set_unescape_uri $key $arg_key ;
 		redis2_query  set $key $echo_request_body;
 		redis2_query expire $key 14400;
-		redis2_pass  ee_redis:6379;
+		redis2_pass  redis:6379;
 	}
 
 	location ~ \.php$ {


### PR DESCRIPTION
Service name - https://github.com/EasyEngine/site-command/blob/0f0907cb92415952884a412e9e801b80dd739560/src/Site_Docker.php#L130 should match the hostname in nginx configuration - https://github.com/EasyEngine/site-command/blob/0f0907cb92415952884a412e9e801b80dd739560/templates/config/nginx/default.conf.mustache#L40





Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>