### PR TITLE
Add composer packages caching in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ script:
 after_script:
   - cat /opt/easyengine/ee.log
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Adding caching for composer packages. 

Not adding caching of docker images because, https://docs.travis-ci.com/user/caching#Things-not-to-cache states the following:

> Large files that are quick to install but slow to download do not benefit from caching, as they take as long to download from the cache as from the original source.

> Docker images are not cached, because we provision a brand new virtual machine for every build.