### PR TITLE
Support global nginx-proxy container

### DIFF
--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -208,8 +208,6 @@ class Site_Command extends EE_Site_Command {
 		$this->level        = 1;
 		try {
 			EE\SiteUtils\create_site_root( $this->site['root'], $this->site['url'] );
-			$this->level = 2;
-			EE\SiteUtils\setup_site_network( $this->site['url'] );
 			$this->level = 3;
 			$this->configure_site_files();
 

--- a/src/Site_Docker.php
+++ b/src/Site_Docker.php
@@ -45,8 +45,12 @@ class Site_Docker {
 				'name' => 'io.easyengine.site=${VIRTUAL_HOST}',
 			],
 		];
-		$nginx['networks']    = $network_default;
-		$nginx['networks']    = [ 'name' => 'global-network' ];
+		$nginx['networks']    = [
+			'net' => [
+				$network_default,
+				[ 'name' => 'global-network' ],
+			]
+		];
 
 		$base[] = $nginx;
 

--- a/src/Site_Docker.php
+++ b/src/Site_Docker.php
@@ -16,7 +16,11 @@ class Site_Docker {
 		$base         = [];
 
 		$restart_default = [ 'name' => 'always' ];
-		$network_default = [ 'name' => 'site-network' ];
+		$network_default = [
+			'net' => [
+				[ 'name' => 'site-network' ]
+			]
+		];
 
 		// nginx configuration.
 		$nginx['service_name'] = [ 'name' => 'nginx' ];

--- a/src/Site_Docker.php
+++ b/src/Site_Docker.php
@@ -46,6 +46,7 @@ class Site_Docker {
 			],
 		];
 		$nginx['networks']    = $network_default;
+		$nginx['networks']    = [ 'name' => 'global-network' ];
 
 		$base[] = $nginx;
 

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -40,7 +40,7 @@ services:
     {{#networks}}
     networks:
     {{#net}}
-      - "{{name}}"
+      - {{name}}
     {{/net}}
     {{/networks}}
 {{/services}}

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -39,15 +39,15 @@ services:
     {{/environment}}
     {{#networks}}
     networks:
-      - {{name}}
+    {{#net}}
+      - "{{name}}"
+    {{/net}}
     {{/networks}}
 {{/services}}
 
 {{#network}}
 networks:
   site-network:
-    external:
-      name: ${VIRTUAL_HOST}
   global-network:
     external:
       name: ee-global-network

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -20,7 +20,7 @@ services:
     command: {{name}}
     {{/command}}
     {{#labels}}
-    labels: 
+    labels:
     {{#label}}
       - "{{name}}"
     {{/label}}
@@ -41,7 +41,6 @@ services:
     networks:
       - {{name}}
     {{/networks}}
-    
 {{/services}}
 
 {{#network}}
@@ -49,4 +48,7 @@ networks:
   site-network:
     external:
       name: ${VIRTUAL_HOST}
-{{/network}}  
+  global-network:
+    external:
+      name: ee-global-network
+{{/network}}


### PR DESCRIPTION
Companion PR of - https://github.com/EasyEngine/easyengine/pull/1187
Adds a global network block in docker-compose and connects nginx server to it.

Earlier it used to be that there was a single network per site and nginx-proxy was connected to it.
Now there is a special `ee-global-network` network. All nginx containers of all sites will be connected to it and there will be seperate site-name network in which all containers of same site will connect. 

Signed-off-by: Kirtan Gajjar <kirtangajjar95@gmail.com>