### PR TITLE
Add vendor label in site-network

### DIFF
--- a/src/Site_Docker.php
+++ b/src/Site_Docker.php
@@ -63,7 +63,8 @@ class Site_Docker {
 			'network'  => [
 				'networks_labels' => [
 					'label' => [
-						'name' => 'org.label-schema.vendor=EasyEngine',
+						[ 'name' => 'org.label-schema.vendor=EasyEngine' ],
+						[ 'name' => 'io.easyengine.site=${VIRTUAL_HOST}' ],
 					],
 				],
 			],

--- a/src/Site_Docker.php
+++ b/src/Site_Docker.php
@@ -60,7 +60,13 @@ class Site_Docker {
 
 		$binding = [
 			'services' => $base,
-			'network'  => true,
+			'network'  => [
+				'networks_labels' => [
+					'label' => [
+						'name' => 'org.label-schema.vendor=EasyEngine',
+					],
+				],
+			],
 		];
 
 		$docker_compose_yml = mustache_render( SITE_TEMPLATE_ROOT . '/docker-compose.mustache', $binding );

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -48,6 +48,12 @@ services:
 {{#network}}
 networks:
   site-network:
+    {{#networks_labels}}
+    labels:
+    {{#label}}
+     - "{{name}}"
+    {{/label}}
+    {{/networks_labels}}
   global-network:
     external:
       name: ee-global-network


### PR DESCRIPTION
Adds vendor and site label to the site network.

This adds labels to networks created from docker-compose.

Partial Fix to EasyEngine/easyengine#1189