### PR TITLE
Fix ssl db values

### DIFF
--- a/migrations/db/20181212035130_site-command_fix_ssl_entries.php
+++ b/migrations/db/20181212035130_site-command_fix_ssl_entries.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace EE\Migration;
+
+use EE;
+use EE\Model\Site;
+use EE\Migration\Base;
+
+class FixSslEntries extends Base {
+
+	public function __construct() {
+
+		parent::__construct();
+		$this->sites = Site::all();
+		if ( $this->is_first_execution || ! $this->sites ) {
+			$this->skip_this_migration = true;
+		}
+	}
+
+	/**
+	 * Execute create table query for site and sitemeta table.
+	 *
+	 * @throws EE\ExitException
+	 */
+	public function up() {
+
+		if ( $this->skip_this_migration ) {
+			EE::debug( 'Skipping ssl-entries migration as it is not needed.' );
+
+			return;
+		}
+		foreach ( $this->sites as $site ) {
+
+			if ( empty( $site->site_ssl ) ) {
+				continue;
+			}
+
+			switch ( $site->site_ssl ) {
+
+				case 'wildcard':
+					$site->site_ssl = 'le';
+					break;
+
+				case 1:
+				case '1':
+				case 'letsencrypt':
+					$cert_dir    = EE_SERVICE_DIR . '/nginx-proxy/certs';
+					$parent_name = implode( '.', array_slice( explode( '.', $site->site_url ), 1 ) );
+					if ( $this->fs->exists( $cert_dir . '/' . $site->site_url . '.crt' ) ) {
+						$site->site_ssl = 'le';
+					} elseif ( $this->fs->exists( $cert_dir . '/' . $parent_name . '.crt' ) ) {
+						$site->site_ssl = 'inherit';
+					}
+					break;
+
+				case 'self':
+					$site->site_ssl_wildcard = 1;
+					break;
+
+				default:
+					break;
+			}
+			$site->save();
+		}
+	}
+
+	/**
+	 * No changes in case of down.
+	 *
+	 * @throws EE\ExitException
+	 */
+	public function down() {
+	}
+}

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -704,6 +704,8 @@ abstract class EE_Site_Command {
 		} elseif ( 'self' === $ssl_type ) {
 			$client = new Site_Self_signed();
 			$client->create_certificate( $site_url );
+			// Update wildcard to 1 as self-signed certs are wildcard by default.
+			$this->site_data['site_ssl_wildcard'] = 1;
 		} else {
 			throw new \Exception( "Unrecognized value in --ssl flag: $ssl_type" );
 		}


### PR DESCRIPTION
SSL values in DB at present are different according to site types. Migrations to make them all same.
Migrations for changes in:

https://github.com/EasyEngine/site-command/pull/258/commits/bd4bbb47ae2ce94db2569168a9e744ed9ff67a2e
https://github.com/EasyEngine/site-type-wp/commit/e484d25d96c58a2c58054da05078bd4673c7f6d1
https://github.com/EasyEngine/site-type-php/commit/c049895531ddb9d92fc0b7721e777275cf8af8b1