### PR TITLE
Fix SSL renewal if certificate is already expired

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -361,6 +361,35 @@ class Site_Letsencrypt {
 	}
 
 	/**
+	 * Check expiry if a certificate is already expired.
+	 *
+	 * @param string $domain
+	 */
+	public function isAlreadyExpired( $domain ) {
+
+		// Check expiration date to avoid too much renewal
+		\EE::log( "Loading current certificate for $domain" );
+
+		$certificate       = $this->repository->loadDomainCertificate( $domain );
+		$certificateParser = new CertificateParser();
+		$parsedCertificate = $certificateParser->parse( $certificate );
+
+		// 2160000 = 25 days.
+		if ( $parsedCertificate->getValidTo()->format( 'U' ) - time() < 0 ) {
+			\EE::log(
+				sprintf(
+					'Current certificate is alerady expired on %s, renewal is necessary.',
+					$parsedCertificate->getValidTo()->format( 'Y-m-d H:i:s' )
+				)
+			);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check expiry of a certificate.
 	 *
 	 * @param string $domain
@@ -598,3 +627,4 @@ class Site_Letsencrypt {
 		}
 	}
 }
+

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -715,9 +715,8 @@ abstract class EE_Site_Command {
 					$this->init_ssl( $this->site_data['site_url'], $this->site_data['site_fs_path'], $this->site_data['site_ssl'], $this->site_data['site_ssl_wildcard'], $is_www_or_non_www_pointed, $force );
 				}
 
-				if ( ! $renew ) {
-					$this->dump_docker_compose_yml( [ 'nohttps' => false ] );
-				}
+				$this->dump_docker_compose_yml( [ 'nohttps' => false ] );
+
 				\EE\Site\Utils\start_site_containers( $this->site_data['site_fs_path'], $containers_to_start );
 			}
 
@@ -1049,6 +1048,11 @@ abstract class EE_Site_Command {
 		}
 
 		$client = new Site_Letsencrypt();
+		if ( $client->isAlreadyExpired( $this->site_data['site_url'] ) ) {
+			$this->dump_docker_compose_yml( [ 'nohttps' => true ] );
+			$this->enable( $args, [ 'force' => true ] );
+		}
+
 		if ( ! $client->isRenewalNecessary( $this->site_data['site_url'] ) ) {
 			return 0;
 		}
@@ -1323,3 +1327,4 @@ abstract class EE_Site_Command {
 	abstract public function dump_docker_compose_yml( $additional_filters = [] );
 
 }
+


### PR DESCRIPTION
Add function to check if cert is already expired.
If already expired then `nohttps -> true` and renew cert.