### PR TITLE
Fix db name with hypen issue

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -216,6 +216,16 @@ abstract class EE_Site_Command {
 			\EE::exec( 'docker volume rm ' . $volume );
 		}
 
+		$db_script_path = \EE\Utils\get_temp_dir() . 'db_exec';
+
+		if ( $this->fs->exists( $db_script_path ) ) {
+			try {
+				$this->fs->remove($db_script_path);
+			} catch (\Exception $e) {
+				\EE::debug($e);
+			}
+		}
+
 		if ( ! empty( $db_data['db_host'] ) ) {
 			\EE\Site\Utils\cleanup_db( $db_data['db_host'], $db_data['db_name'] );
 			\EE\Site\Utils\cleanup_db_user( $db_data['db_host'], $db_data['db_user'] );

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -244,9 +244,9 @@ abstract class EE_Site_Command {
 
 		if ( $this->fs->exists( $db_script_path ) ) {
 			try {
-				$this->fs->remove($db_script_path);
-			} catch (\Exception $e) {
-				\EE::debug($e);
+				$this->fs->remove( $db_script_path );
+			} catch ( \Exception $e ) {
+				\EE::debug( $e );
 			}
 		}
 

--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -147,7 +147,7 @@ function create_user_in_db( $db_host, $db_name = '', $db_user = '', $db_pass = '
 	$db_user = empty( $db_user ) ? \EE\Utils\random_password( 5 ) : $db_user;
 	$db_pass = empty( $db_pass ) ? \EE\Utils\random_password() : $db_pass;
 
-	//TODO: Create database only if it does not exist
+	// TODO: Create database only if it does not exist.
 	$create_string = sprintf( 'CREATE USER "%1$s"@"%%" IDENTIFIED BY "%2$s"; CREATE DATABASE `%3$s`; GRANT ALL PRIVILEGES ON `%3$s`.* TO "%1$s"@"%%"; FLUSH PRIVILEGES;', $db_user, $db_pass, $db_name );
 
 	if ( GLOBAL_DB === $db_host ) {

--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -129,7 +129,7 @@ function create_user_in_db( $db_host, $db_name = '', $db_user = '', $db_pass = '
 	$db_user = empty( $db_user ) ? \EE\Utils\random_password( 5 ) : $db_user;
 	$db_pass = empty( $db_pass ) ? \EE\Utils\random_password() : $db_pass;
 
-	$create_string = sprintf( "CREATE USER '%1\$s'@'%%' IDENTIFIED BY '%2\$s'; CREATE DATABASE %3\$s; GRANT ALL PRIVILEGES ON %3\$s.* TO '%1\$s'@'%%'; FLUSH PRIVILEGES;", $db_user, $db_pass, $db_name );
+	$create_string = sprintf( 'CREATE USER "%1$s"@"%%" IDENTIFIED BY "%2$s"; CREATE DATABASE `%3$s`; GRANT ALL PRIVILEGES ON `%3$s`.* TO "%1$s"@"%%"; FLUSH PRIVILEGES;', $db_user, $db_pass, $db_name );
 
 	if ( GLOBAL_DB === $db_host ) {
 
@@ -148,7 +148,7 @@ function create_user_in_db( $db_host, $db_name = '', $db_user = '', $db_pass = '
 		}
 
 		$db_script_path = \EE\Utils\get_temp_dir() . 'db_exec';
-		file_put_contents( $db_script_path, sprintf( 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e"%s"', $create_string ) );
+		file_put_contents( $db_script_path, sprintf( 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e\'%s\'', $create_string ) );
 
 		EE::exec( sprintf( 'docker cp %s %s:/db_exec', $db_script_path, GLOBAL_DB_CONTAINER ) );
 		if ( ! EE::exec( sprintf( 'docker exec %s sh db_exec', GLOBAL_DB_CONTAINER ) ) ) {

--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -194,11 +194,11 @@ function create_user_in_db( $db_host, $db_name = '', $db_user = '', $db_pass = '
  */
 function cleanup_db( $db_host, $db_name, $db_user = '', $db_pass = '' ) {
 
-	$cleanup_string = sprintf( 'DROP DATABASE %s;', $db_name );
+	$cleanup_string = sprintf( 'DROP DATABASE `%s`;', $db_name );
 
 	if ( GLOBAL_DB === $db_host ) {
 		$db_script_path = \EE\Utils\get_temp_dir() . 'db_exec';
-		file_put_contents( $db_script_path, sprintf( 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e"%s"', $cleanup_string ) );
+		file_put_contents( $db_script_path, sprintf( 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e\'%s\'', $cleanup_string ) );
 
 		EE::exec( sprintf( 'docker cp %s %s:/db_exec', $db_script_path, GLOBAL_DB_CONTAINER ) );
 		EE::exec( sprintf( 'docker exec %s sh db_exec', GLOBAL_DB_CONTAINER ) );

--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -129,6 +129,7 @@ function create_user_in_db( $db_host, $db_name = '', $db_user = '', $db_pass = '
 	$db_user = empty( $db_user ) ? \EE\Utils\random_password( 5 ) : $db_user;
 	$db_pass = empty( $db_pass ) ? \EE\Utils\random_password() : $db_pass;
 
+	//TODO: Create database only if it does not exist
 	$create_string = sprintf( 'CREATE USER "%1$s"@"%%" IDENTIFIED BY "%2$s"; CREATE DATABASE `%3$s`; GRANT ALL PRIVILEGES ON `%3$s`.* TO "%1$s"@"%%"; FLUSH PRIVILEGES;', $db_user, $db_pass, $db_name );
 
 	if ( GLOBAL_DB === $db_host ) {


### PR DESCRIPTION
This PR fixes issue where if you specify a dbname with hyphen, you won't be able to create db. See - https://community.easyengine.io/t/cant-create-a-website-with-dbname-option/13926

What this PR does is, it replaces `"` with `'` and wraps db name in backticks `.
i.e.

Before:
```
mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e"CREATE USER 'example.local-N4Ujuo'@'%' IDENTIFIED BY 'ZrNCJlx2KfsI'; CREATE DATABASE humo-gen; GRANT ALL PRIVILEGES ON humo-gen.* TO 'example.local-N4Ujto'@'%'; FLUSH PRIVILEGES;"
```
After:
```
mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e'CREATE USER "example.local-N4Ujuo"@"%" IDENTIFIED BY "ZrNCJlx2KfsI"; CREATE DATABASE `humo-gen`; GRANT ALL PRIVILEGES ON `humo-gen`.* TO "example.local-N4Ujto"@"%"; FLUSH PRIVILEGES;"
```

Also, I noticed in some cases when site creation fails and if `/tmp/db_exec` is not removed, site creation fails, so I've removed that file on site deletion.

Closes: https://github.com/EasyEngine/easyengine/issues/1459
