### PR TITLE
Make the code compatible with PHP 7.4

### DIFF
--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -11,7 +11,7 @@ class Site_Command {
 	/**
 	 * @var array $site_types Array to hold all the registered site types and their callback classes.
 	 */
-	protected static $site_types = [];
+	protected $site_types = [];
 
 	/**
 	 * @var Site_Command $instance Hold an instance of the class.
@@ -39,7 +39,9 @@ class Site_Command {
 	 * @param string $callback The callback function/class for that type.
 	 */
 	public static function add_site_type( $name, $callback ) {
-
+		if ( !isset( self::$instance ) )
+			self::$instance = self::instance();
+		
 		if ( isset( self::$instance->site_types[ $name ] ) ) {
 			EE::warning( sprintf( '%s site-type had already been previously registered by %s. It is overridden by the new package class %s. Please update your packages to resolve this.', $name, self::$instance->site_types[ $name ], $callback ) );
 		}


### PR DESCRIPTION
During some tests using PHP 7.4, I found a warring notice like this:
`PHP Warning:  Creating default object from empty value in /root/workspace/easyengine-74/vendor/easyengine/site-command/src/Site_Command.php on line 46`
This is happen when trying to access a property or method but it is null, or the object is not yet initialized. To fix this, I check if the object exist first.