### PR TITLE
Disallow site sync to production server

### DIFF
--- a/src/clone/Cloner.php
+++ b/src/clone/Cloner.php
@@ -298,7 +298,7 @@ class Site {
 		}
 
 		if ( 0 !== $site_list->return_code ) {
-			throw new \Exception( 'Unable to get site list on remote server.' );
+			throw new \Exception( 'Unable to get site list on ' . $this->user . '@' . $this->host );
 		}
 
 		$sites = json_decode( $site_list->stdout, true );
@@ -336,6 +336,11 @@ class Site {
 		if ( ! $this->ssh_success() ) {
 			throw new \Exception( 'Unable to SSH to ' . $this->host );
 		}
+	}
+
+	public function is_production(): bool {
+		$output = $this->execute( 'ee config get env' );
+		return 'production' === strtolower( trim( $output->stdout ) );
 	}
 
 	function set_site_details(): void {

--- a/src/clone/clone-utils.php
+++ b/src/clone/clone-utils.php
@@ -171,6 +171,9 @@ function check_site_access( Site $source_site, Site $destination_site, $sync = f
 	$source_site->set_site_details();
 
 	if ( $sync ) {
+		if ( $destination_site->is_production() ) {
+			EE::error( 'Can not sync to a production server.' );
+		}
 		$destination_site->ensure_site_exists();
 		$destination_site->set_site_details();
 	}


### PR DESCRIPTION
If destination server has `ee config set env production`
Then do not sync any site to that server.