### PR TITLE
Add support for Cloudflare API Token replacing legacy API Key

### DIFF
--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -113,7 +113,7 @@ class Site_Command {
 					continue;
 				}
 
-				$api_key_absent        = empty( EE\Utils\get_config_value( 'cloudflare-api-key' ) );
+				$api_key_absent        = empty( EE\Utils\get_config_value( 'cloudflare-api-key' ) ) &&  empty ( get_config_value( 'cloudflare-api-token' ) );
 				$skip_wildcard_warning = false;
 
 				if ( $site->site_ssl_wildcard && $api_key_absent ) {

--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -198,7 +198,7 @@ class Site_Letsencrypt {
 	public function authorize( Array $domains, $wildcard = false, $preferred_challenge = '' ) {
 		$is_solver_dns = ( $wildcard || 'dns' === $preferred_challenge ) ? true : false;
 		if ( $is_solver_dns ) {
-			$solver = empty ( get_config_value( 'cloudflare-api-key' ) ) ? new SimpleDnsSolver( null, new ConsoleOutput() ) : new SimpleDnsCloudflareSolver( null, new ConsoleOutput() );
+			$solver = empty ( get_config_value( 'cloudflare-api-key' ) ) &&  empty ( get_config_value( 'cloudflare-api-token' ) ) ? new SimpleDnsSolver( null, new ConsoleOutput() ) : new SimpleDnsCloudflareSolver( null, new ConsoleOutput() );
 		} else {
 			$solver = new SimpleHttpSolver();
 		}
@@ -338,7 +338,7 @@ class Site_Letsencrypt {
 		$is_solver_dns = ( $wildcard || 'dns' === $preferred_challenge ) ? true : false;
 		\EE::debug( ( 'Starting check with solver ' ) . ( $is_solver_dns ? 'dns' : 'http' ) );
 		if ( $is_solver_dns ) {
-			$solver = empty ( get_config_value( 'cloudflare-api-key' ) ) ? new SimpleDnsSolver( null, new ConsoleOutput() ) : new SimpleDnsCloudflareSolver( null, new ConsoleOutput() );
+			$solver = empty ( get_config_value( 'cloudflare-api-key' ) ) &&  empty ( get_config_value( 'cloudflare-api-token' ) ) ? new SimpleDnsSolver( null, new ConsoleOutput() ) : new SimpleDnsCloudflareSolver( null, new ConsoleOutput() );
 		} else {
 			$solver = new SimpleHttpSolver();
 		}

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -1515,7 +1515,7 @@ abstract class EE_Site_Command {
 		if ( ! $client->authorize( $domains, $wildcard, $preferred_challenge ) ) {
 			return;
 		}
-		$api_key_absent = empty( get_config_value( 'cloudflare-api-key' ) );
+		$api_key_absent = empty( get_config_value( 'cloudflare-api-key' ) ) &&  empty ( get_config_value( 'cloudflare-api-token' ) );
 		if ( $is_solver_dns && $api_key_absent ) {
 			echo \cli\Colors::colorize( '%YIMPORTANT:%n Run `ee site ssl-verify ' . $site_url . '` once the DNS changes have propagated to complete the certification generation and installation.', null );
 		} else {
@@ -1621,7 +1621,7 @@ abstract class EE_Site_Command {
 
 		// This checks if this method was called internally by ee or by user
 		$called_by_ee   = ! empty( $this->site_data['site_url'] );
-		$api_key_absent = empty( get_config_value( 'cloudflare-api-key' ) );
+		$api_key_absent = empty( get_config_value( 'cloudflare-api-key' ) ) &&  empty ( get_config_value( 'cloudflare-api-token' ) );
 
 		if ( ! $called_by_ee ) {
 			$this->site_data = get_site_info( $args );
@@ -1646,7 +1646,7 @@ abstract class EE_Site_Command {
 				throw $e;
 			}
 			$is_solver_dns   = ( $this->site_data['site_ssl_wildcard'] || 'dns' === $preferred_challenge ) ? true : false;
-			$api_key_present = ! empty( get_config_value( 'cloudflare-api-key' ) );
+			$api_key_present = ! empty( get_config_value( 'cloudflare-api-key' ) ) &&  ! empty ( get_config_value( 'cloudflare-api-token' ) );
 
 			if ( $called_by_ee && ! $is_solver_dns && $api_key_present ) {
 				throw $e;
@@ -1712,7 +1712,7 @@ abstract class EE_Site_Command {
 
 		if ( $all ) {
 			$sites                 = Site::all();
-			$api_key_absent        = empty( get_config_value( 'cloudflare-api-key' ) );
+			$api_key_absent        = empty( get_config_value( 'cloudflare-api-key' ) ) &&  empty ( get_config_value( 'cloudflare-api-token' ) );
 			$skip_wildcard_warning = false;
 			foreach ( $sites as $site ) {
 				if ( 'le' !== $site->site_ssl || ! $site->site_enabled ) {


### PR DESCRIPTION
As stated here: https://developers.cloudflare.com/fundamentals/api/get-started/keys/

> Global API key is the previous authorization scheme for interacting with the Cloudflare API. When possible, use [API tokens](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/) instead of Global API key.

This small pull request will add support for users to use Cloudflare API tokens instead of email+API Key (which could also solve the problem stated here #302 ) that is more secured settings than entering the global API key.

As a result, only API token is needed, users won't need to set their Cloudflare email.

set the config
```bash
ee config set cloudflare-api-token <cf-api-token>
```

renew SSL
```bash
ee site ssl-renew <site-name>
```