### PR TITLE
site-utils.php: Handle checking of links properly

### DIFF
--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -64,8 +64,8 @@ function auto_site_name( $args, $command, $function, $arg_pos = 0 ) {
 
 	if ( isset( $args[ $arg_pos ] ) ) {
 		$possible_site_name = $args[ $arg_pos ];
-		if ( substr( $possible_site_name, 0, 4 ) === 'http' ) {
-			$possible_site_name = str_replace( [ 'https', 'http' ], '', $possible_site_name );
+		if ( substr( $possible_site_name, 0, 7 ) === 'http://' || substr( $possible_site_name, 0, 8 ) === 'https://' ) {
+			$possible_site_name = str_replace( [ 'https://', 'http://' ], '', $possible_site_name );
 		}
 		$url_path = parse_url( EE\Utils\remove_trailing_slash( $possible_site_name ), PHP_URL_PATH );
 		if ( Site::find( $url_path ) ) {


### PR DESCRIPTION
```
╭─root@immanuelraj.rt.gw ~  
╰─➤  ee auth create httpauth1.immanuelraj.rt.gw
Error: Could not find the site you wish to run auth create command on.
Either pass it as an argument: `ee auth create <site-name>` 
or run `ee auth create` from inside the site folder.
```
But if the site name doesn't start with HTTP then it will allow it
```
╭─root@immanuelraj.rt.gw ~  
╰─➤  ee auth create testhttpauth.immanuelraj.rt.gw                                                                                                                              1 ↵
Reloading global reverse proxy.
Success: Auth successfully updated for `testhttpauth.immanuelraj.rt.gw` scope. New values added:
User: ee-SzkPrf
Pass: PjRg6O4adjM6Te49ac
````
This commit fixes that