### PR TITLE
docs: add compatibility note for EasyEngine v4.7+, WordPress 6.7+, PHP 8.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 easyengine/site-command
 =======================
 
+> ✅ Compatible with EasyEngine v4.7+, WordPress 6.7+, PHP 8.2+
+
 
 
 [![Build Status](https://travis-ci.org/easyengine/site-command.svg?branch=master)](https://travis-ci.org/easyengine/site-command)


### PR DESCRIPTION
This PR updates the README to clarify compatibility with EasyEngine v4.7+, WordPress 6.7+, and PHP 8.2+ to help developers and users.
