### PR TITLE
Flush MySQL privileges before database backup

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -360,6 +360,11 @@ class Site_Backup_Restore {
 	}
 
 	private function backup_db( $backup_dir ) {
+		// Flush MySQL privileges before backup
+		if ( 'running' === \EE_DOCKER::container_status( GLOBAL_DB_CONTAINER ) ) {
+			EE::exec( 'docker exec -it ' . GLOBAL_DB_CONTAINER . " bash -c 'mysql -uroot -p\$MYSQL_ROOT_PASSWORD -e\"FLUSH PRIVILEGES\"'" );
+		}
+
 		EE::log( 'Backing up database.' );
 		$db_name      = $this->site_data['db_name'];
 		$db_user      = $this->site_data['db_user'];


### PR DESCRIPTION
This pull request introduces a small but important change to the database backup process in `Site_Backup_Restore.php`. Before backing up the database, the code now flushes MySQL privileges to ensure all recent changes to user permissions are saved.

Database backup reliability:

* [`src/helper/Site_Backup_Restore.php`](diffhunk://#diff-91f3385f2b73c4fd66e7544007fa63b34aa8cbd86ed988dcc348c9dfb34d2109R363-R367): Added a step to flush MySQL privileges in the `backup_db` method before performing the database backup, improving the reliability of permission backups.