### PR TITLE
Skip cert generation if certs dir missing

### DIFF
--- a/migrations/container/20250903101855_site-command_generate_default_self_signed_cert.php
+++ b/migrations/container/20250903101855_site-command_generate_default_self_signed_cert.php
@@ -16,6 +16,10 @@ class GenerateDefaultSelfSignedCert extends Base {
 		$this->certs_dir = EE_ROOT_DIR . '/services/nginx-proxy/certs';
 		$this->key_path  = $this->certs_dir . '/default.key';
 		$this->crt_path  = $this->certs_dir . '/default.crt';
+
+		if ( ! $this->fs->exists( $this->certs_dir ) ) {
+			$this->skip_this_migration = true;
+		}
 	}
 
 	/**
@@ -23,6 +27,13 @@ class GenerateDefaultSelfSignedCert extends Base {
 	 * @throws EE\ExitException
 	 */
 	public function up() {
+
+		if ( $this->skip_this_migration ) {
+			EE::debug( 'Skipping default self-signed cert generation migration as it is not needed.' );
+
+			return;
+		}
+
 		if ( $this->fs->exists( $this->key_path ) && $this->fs->exists( $this->crt_path ) ) {
 			EE::debug( 'Default self-signed cert already exists. Skipping generation.' );
 


### PR DESCRIPTION
This pull request introduces a safeguard to the migration process for generating a default self-signed certificate. The main change ensures that the migration is skipped if the required certificates directory does not exist, preventing unnecessary operations and potential errors.

Migration process improvement:

* Added a check in the constructor of the migration class to set a flag (`skip_this_migration`) if the `certs_dir` directory does not exist, and updated the `up()` method to skip the migration and log a debug message when this flag is set.