### PR TITLE
Fix/cert return

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -638,6 +638,8 @@ class Site_Letsencrypt {
 			$this->moveCertsToNginxProxy( $domain );
 			\EE::log( 'Certificate renewed successfully!' );
 
+			return true;
+
 		} catch ( \Exception $e ) {
 			\EE::warning( 'A critical error occured during certificate renewal' );
 			\EE::debug( print_r( $e, true ) );

--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -488,6 +488,8 @@ class Site_Letsencrypt {
 
 		// Post-generate actions
 		$this->moveCertsToNginxProxy( $domain );
+
+		return true;
 	}
 
 	private function moveCertsToNginxProxy( string $domain ) {


### PR DESCRIPTION
This pull request makes minor improvements to the `Site_Letsencrypt.php` helper by ensuring that the `executeFirstRequest` and `executeRenewal` methods consistently return `true` upon successful completion. This helps clarify the expected return value and can improve error handling or control flow in code that calls these methods.

- Consistency improvements:
  * Added a `return true;` statement at the end of the `executeFirstRequest` method to explicitly indicate successful completion.
  * Added a `return true;` statement at the end of the try block in the `executeRenewal` method, before the exception handling, to signal successful execution.