### PR TITLE
Add ssl-dns-info command to display DNS-01 TXT record values post site creation

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -738,5 +738,26 @@ class Site_Letsencrypt {
 			$fs->remove( $challange_dir );
 		}
 	}
-}
 
+	/**
+	 * Check if a domain has a stored ACME authorization challenge.
+	 *
+	 * @param string $domain The domain to check for a stored challenge.
+	 *
+	 * @return bool True if a challenge exists for the domain, false otherwise.
+	 */
+	public function hasDomainAuthorizationChallenge( $domain ) {
+		return $this->repository->hasDomainAuthorizationChallenge( $domain );
+	}
+
+	/**
+	 * Load the stored ACME authorization challenge for a domain.
+	 *
+	 * @param string $domain The domain to load the challenge for.
+	 *
+	 * @return AuthorizationChallenge|null The challenge object, or null if not found.
+	 */
+	public function loadDomainAuthorizationChallenge( $domain ) {
+		return $this->repository->loadDomainAuthorizationChallenge( $domain );
+	}
+}


### PR DESCRIPTION
This pull request introduces a new CLI command to display DNS TXT records required for DNS-based SSL challenges, and adds supporting methods to facilitate this functionality. The changes make it easier for users to retrieve and display DNS challenge information for SSL certificate issuance, especially for sites using DNS-01 challenges.

**New CLI command for DNS challenge info:**

* Added a new `ssl-dns-info` subcommand to the site CLI, which prints the DNS TXT record(s) needed for DNS-based SSL challenges. The command supports multiple output formats and provides clear feedback if no DNS challenge is found or if the site does not use DNS-01. (`class-ee-site.php`)

**Supporting methods in Let's Encrypt helper:**

* Added `hasDomainAuthorizationChallenge($domain)` and `loadDomainAuthorizationChallenge($domain)` methods to the `Site_Letsencrypt` helper to check for and retrieve stored ACME authorization challenges for a given domain. (`Site_Letsencrypt.php`)