### PR TITLE
feat(redirects): check for SSL cert/key before adding redirects

### DIFF
--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -273,22 +273,31 @@ function add_site_redirects( string $site_url, bool $ssl, bool $inherit ) {
 		$cert_site_name = implode( '.', array_slice( explode( '.', $site_url ), 1 ) );
 	}
 
-	if ( $has_www ) {
-		$server_name = ltrim( $site_url, '.www' );
+	// Check for existence of cert and key files for the cert_site_name
+	$certs_dir = EE_ROOT_DIR . '/services/nginx-proxy/certs/';
+	$crt_file = $certs_dir . $cert_site_name . '.crt';
+	$key_file = $certs_dir . $cert_site_name . '.key';
+
+	if ( file_exists( $crt_file ) && file_exists( $key_file ) ) {
+		if ( $has_www ) {
+			$server_name = ltrim( $site_url, '.www' );
+		} else {
+			$server_name = 'www.' . $site_url;
+		}
+
+		$conf_data = [
+			'site_name'      => $site_url,
+			'cert_site_name' => $cert_site_name,
+			'server_name'    => $server_name,
+			'ssl'            => $ssl,
+			$conf_ssl_policy => true,
+		];
+
+		$content = EE\Utils\mustache_render( SITE_TEMPLATE_ROOT . '/redirect.conf.mustache', $conf_data );
+		$fs->dumpFile( $config_file_path, ltrim( $content, PHP_EOL ) );
 	} else {
-		$server_name = 'www.' . $site_url;
+		EE::log( sprintf( 'SSL cert/key missing for %s, skipping redirect config.', $cert_site_name ) );
 	}
-
-	$conf_data = [
-		'site_name'      => $site_url,
-		'cert_site_name' => $cert_site_name,
-		'server_name'    => $server_name,
-		'ssl'            => $ssl,
-		$conf_ssl_policy => true,
-	];
-
-	$content = EE\Utils\mustache_render( SITE_TEMPLATE_ROOT . '/redirect.conf.mustache', $conf_data );
-	$fs->dumpFile( $config_file_path, ltrim( $content, PHP_EOL ) );
 }
 
 /**

--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -275,8 +275,8 @@ function add_site_redirects( string $site_url, bool $ssl, bool $inherit ) {
 
 	// Check for existence of cert and key files for the cert_site_name
 	$certs_dir = EE_ROOT_DIR . '/services/nginx-proxy/certs/';
-	$crt_file = $certs_dir . $cert_site_name . '.crt';
-	$key_file = $certs_dir . $cert_site_name . '.key';
+	$crt_file  = $certs_dir . $cert_site_name . '.crt';
+	$key_file  = $certs_dir . $cert_site_name . '.key';
 
 	if ( file_exists( $crt_file ) && file_exists( $key_file ) ) {
 		if ( $has_www ) {


### PR DESCRIPTION
This pull request adds a check to ensure that SSL certificate and key files exist before generating redirect configurations in the `add_site_redirects` function. If the required files are missing, it logs a message and skips creating the redirect configuration. This helps prevent configuration errors due to missing SSL files.

**SSL Certificate Verification and Logging:**

* Added logic to check for the existence of the SSL certificate (`.crt`) and key (`.key`) files for the target site before generating the redirect configuration in `add_site_redirects`. If the files are missing, the function logs a message and skips creating the redirect config. (`src/helper/site-utils.php`, [[1]](diffhunk://#diff-90cf1ab43083fb368b9718b5606e7b1bf143209e6c7d65c9fa584473acb87de5R276-R281) [[2]](diffhunk://#diff-90cf1ab43083fb368b9718b5606e7b1bf143209e6c7d65c9fa584473acb87de5R298-R300)