### PR TITLE
feat(site): update add_site_redirects to handle redirect for non-ssl

### DIFF
--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -278,7 +278,7 @@ function add_site_redirects( string $site_url, bool $ssl, bool $inherit ) {
 	$crt_file  = $certs_dir . $cert_site_name . '.crt';
 	$key_file  = $certs_dir . $cert_site_name . '.key';
 
-	if ( file_exists( $crt_file ) && file_exists( $key_file ) ) {
+	if ( ( $ssl && file_exists( $crt_file ) && file_exists( $key_file ) ) || ! $ssl ) {
 		if ( $has_www ) {
 			$server_name = ltrim( $site_url, '.www' );
 		} else {


### PR DESCRIPTION
This pull request makes a small but important change to the SSL certificate check logic in the `add_site_redirects` function. Now, certificate file existence is only required when SSL is enabled, allowing non-SSL sites to bypass this check.

* Updated the conditional in `add_site_redirects` in `site-utils.php` to require certificate files only when `$ssl` is true, making the function more flexible for non-SSL site redirects.