### PR TITLE
Adjust DNS record name for wildcard domains

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -1733,7 +1733,7 @@ abstract class EE_Site_Command {
 	 * [--format=<format>]
 	 * : Render output in a particular format.
 	 * ---
-	 * default: table
+	 * default: json
 	 * options:
 	 *   - table
 	 *   - csv

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -1780,7 +1780,7 @@ abstract class EE_Site_Command {
 						if ( method_exists( $challenge, 'toArray' ) ) {
 							$data        = $challenge->toArray();
 							// Always use _acme-challenge.base-domain for wildcard domains
-							if ( strpos( $domain, '*.' ) === 0 ) {
+							if ( 0 === strpos( $domain, '*.' ) ) {
 								$base_domain = substr( $domain, 2 );
 								$record_name = '_acme-challenge.' . $base_domain;
 							} else {

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -1779,7 +1779,13 @@ abstract class EE_Site_Command {
 						$challenge = $client->loadDomainAuthorizationChallenge( $domain );
 						if ( method_exists( $challenge, 'toArray' ) ) {
 							$data        = $challenge->toArray();
-							$record_name = isset( $data['dnsRecordName'] ) ? $data['dnsRecordName'] : '_acme-challenge.' . $domain;
+							// Always use _acme-challenge.base-domain for wildcard domains
+							if ( strpos( $domain, '*.' ) === 0 ) {
+								$base_domain = substr( $domain, 2 );
+								$record_name = '_acme-challenge.' . $base_domain;
+							} else {
+								$record_name = isset( $data['dnsRecordName'] ) ? $data['dnsRecordName'] : '_acme-challenge.' . $domain;
+							}
 							if ( isset( $data['dnsRecordValue'] ) ) {
 								$record_value = $data['dnsRecordValue'];
 							} elseif ( isset( $data['payload'] ) ) {


### PR DESCRIPTION
This pull request introduces improvements to how SSL information is handled for sites, with a focus on enhancing DNS record generation for wildcard domains and updating the default output format for SSL verification commands.

Improvements to SSL information handling:

* Updated the logic in `ssl_info` to always use `_acme-challenge.base-domain` as the DNS record name for wildcard domains, ensuring correct DNS challenge setup for SSL certificates.

Command output changes:

* Changed the default output format for the `ssl_verify` command from `table` to `json`, making it easier to consume results programmatically.