### PR TITLE
fix(backup): handle 7z exit codes correctly to avoid false failures

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -480,7 +480,7 @@ class Site_Backup_Restore {
 		$result         = EE::launch( $backup_command );
 
 		// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error
-		if ( $result->return_code >= 2 ) {
+		if ( $result->return_code >= 2 || ! $this->fs->exists( $backup_file ) ) {
 			$this->capture_error(
 				'Failed to create WordPress content backup archive',
 				self::ERROR_TYPE_FILESYSTEM,
@@ -499,7 +499,7 @@ class Site_Backup_Restore {
 		$this->fs->remove( $meta_file );
 
 		// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error
-		if ( $result->return_code >= 2 ) {
+		if ( $result->return_code >= 2 || ! $this->fs->exists( $backup_file ) ) {
 			$this->capture_error(
 				'Failed to create WordPress content backup archive',
 				self::ERROR_TYPE_FILESYSTEM,
@@ -642,7 +642,7 @@ class Site_Backup_Restore {
 		$result = EE::launch( $backup_command );
 
 		// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error
-		if ( $result->return_code >= 2 ) {
+		if ( $result->return_code >= 2 || ! $this->fs->exists( $backup_file ) ) {
 			$this->capture_error(
 				'Failed to compress database backup into archive',
 				self::ERROR_TYPE_FILESYSTEM,

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -419,7 +419,7 @@ class Site_Backup_Restore {
 		if ( $this->fs->exists( $custom_docker_compose_dir ) ) {
 			$custom_docker_compose_dir_archive = $backup_dir . '/user-docker-compose.zip';
 			$archive_command                   = sprintf( 'cd %s && 7z a -mx=1 %s .', $custom_docker_compose_dir, $custom_docker_compose_dir_archive );
-			$result = EE::launch( $archive_command );
+			$result                            = EE::launch( $archive_command );
 
 			// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error
 			// This is optional, so we just log a warning instead of failing
@@ -477,7 +477,7 @@ class Site_Backup_Restore {
 		}
 
 		$backup_command = sprintf( 'cd %s && 7z a -mx=1 %s wp-config.php', $site_dir . '/../', $backup_file );
-		$result = EE::launch( $backup_command );
+		$result         = EE::launch( $backup_command );
 
 		// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error
 		if ( $result->return_code >= 2 ) {
@@ -494,7 +494,7 @@ class Site_Backup_Restore {
 
 		// Include meta.json in the zip archive (Corrected logic)
 		$backup_command = sprintf( 'cd %s && 7z u -snl -mx=1 %s %s wp-content', $site_dir, $backup_file, $meta_file );
-		$result = EE::launch( $backup_command );
+		$result         = EE::launch( $backup_command );
 		// Remove the file
 		$this->fs->remove( $meta_file );
 
@@ -511,7 +511,7 @@ class Site_Backup_Restore {
 		$uploads_dir = $site_dir . '/wp-content/uploads';
 		if ( is_link( $uploads_dir ) ) {
 			$backup_command = sprintf( 'cd %s && 7z u -mx=1 %s wp-content/uploads', $site_dir, $backup_file );
-			$result = EE::launch( $backup_command );
+			$result         = EE::launch( $backup_command );
 
 			// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error
 			if ( $result->return_code >= 2 ) {


### PR DESCRIPTION
7z returns exit code 1 for non-fatal warnings (e.g., missing symlink targets like broken log file symlinks), but the archive is still created successfully. Previously, EE::exec() returned false for any non-zero exit code, causing false positive backup failures.

Changes:
- Switch from EE::exec() to EE::launch() to get actual exit codes
- Only fail on exit code >= 2 (fatal errors), allow exit code 1 (warnings)
- Add file existence checks as secondary validation
- Custom docker-compose backup logs warning instead of failing (optional)

7z exit code reference:
- 0: Success
- 1: Warning (non-fatal, archive created)
- 2: Fatal error
- 7: Command line error
- 8: Not enough memory

Updated functions:
- maybe_backup_custom_docker_compose()
- backup_site_dir()
- backup_wp_content_dir()
- backup_nginx_conf()
- backup_php_conf()
- backup_db()
