### PR TITLE
Improvements for handling site disabled state in backup

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -50,13 +50,14 @@ class Site_Backup_Restore {
 
 	public function backup( $args, $assoc_args = [] ) {
 		delem_log( 'site backup start' );
-		$args        = auto_site_name( $args, 'site', __FUNCTION__ );
+		$args         = auto_site_name( $args, 'site', __FUNCTION__ );
 		$list_backups = \EE\Utils\get_flag_value( $assoc_args, 'list' );
 		$dash_auth    = \EE\Utils\get_flag_value( $assoc_args, 'dash-auth' );
 
-		// For dash-auth commands, we need to handle site disabled state specially
-		// to send API callback instead of just exiting with error
-		if ( $dash_auth ) {
+		// For --list or --dash-auth, we handle site disabled state specially
+		// --list is read-only and should work regardless of site state
+		// --dash-auth needs to send API callback instead of just exiting with error
+		if ( $list_backups || $dash_auth ) {
 			$this->site_data = get_site_info( $args, false, true, true );
 		} else {
 			$this->site_data = get_site_info( $args, true, true, true );
@@ -77,11 +78,6 @@ class Site_Backup_Restore {
 			// Parse backup-id:backup-verification-token format
 			$auth_parts = explode( ':', $dash_auth, 2 );
 			if ( count( $auth_parts ) !== 2 || empty( $auth_parts[0] ) || empty( $auth_parts[1] ) ) {
-				$this->capture_error(
-					'Invalid --dash-auth format. Expected: backup-id:backup-verification-token',
-					self::ERROR_TYPE_VALIDATION,
-					1001
-				);
 				EE::error( 'Invalid --dash-auth format. Expected: backup-id:backup-verification-token' );
 			}
 
@@ -92,6 +88,7 @@ class Site_Backup_Restore {
 			}
 
 			// Store dash auth info in class properties for shutdown handler
+			// Must be set before any capture_error calls so API callbacks work
 			$this->dash_auth_enabled = true;
 			$this->dash_backup_id    = $auth_parts[0];
 			$this->dash_verify_token = $auth_parts[1];
@@ -106,13 +103,10 @@ class Site_Backup_Restore {
 			register_shutdown_function( [ $this, 'dash_shutdown_handler' ] );
 
 			// Check if site is disabled - send API callback with error
-			if ( empty( $this->site_data['site_enabled'] ) ) {
-				$this->capture_error(
-					sprintf( 'Site %s is disabled. Enable it with `ee site enable %s` to create backup.', $this->site_data['site_url'], $this->site_data['site_url'] ),
-					self::ERROR_TYPE_VALIDATION,
-					1003
-				);
-				EE::error( sprintf( 'Site %s is disabled. Enable it with `ee site enable %s` to create backup.', $this->site_data['site_url'], $this->site_data['site_url'] ) );
+			if ( ! $this->site_data['site_enabled'] ) {
+				$error_msg = sprintf( 'Site %s is disabled. Enable it with `ee site enable %s` to create backup.', $this->site_data['site_url'], $this->site_data['site_url'] );
+				$this->capture_error( $error_msg, self::ERROR_TYPE_VALIDATION, 1003 );
+				EE::error( $error_msg );
 			}
 		}
 
@@ -173,6 +167,8 @@ class Site_Backup_Restore {
 
 		// Release global backup lock (also released by shutdown handler as safety net)
 		$this->release_global_backup_lock();
+
+		EE::success( 'Backup created successfully.' );
 
 		delem_log( 'site backup end' );
 	}
@@ -1580,7 +1576,7 @@ class Site_Backup_Restore {
 					) );
 				}
 				sleep( $retry_delay );
-				$attempt++; // Increment at end of loop iteration
+				$attempt ++; // Increment at end of loop iteration
 			} else {
 				// Either not a retryable error, or we've exhausted all retries
 				if ( $error ) {

--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -2498,9 +2498,8 @@ abstract class EE_Site_Command {
 	 *     $ ee site backup example.com --list
 	 */
 	public function backup( $args, $assoc_args ) {
-		$args            = auto_site_name( $args, 'site', __FUNCTION__ );
-		$this->site_data = get_site_info( $args, true, true, true );
-		$backup_restore  = new Site_Backup_Restore();
+		$args           = auto_site_name( $args, 'site', __FUNCTION__ );
+		$backup_restore = new Site_Backup_Restore();
 		$backup_restore->backup( $args, $assoc_args );
 	}
 
@@ -2525,9 +2524,8 @@ abstract class EE_Site_Command {
 	 *
 	 */
 	public function restore( $args, $assoc_args ) {
-		$args            = auto_site_name( $args, 'site', __FUNCTION__ );
-		$this->site_data = get_site_info( $args, true, true, true );
-		$backup_restore  = new Site_Backup_Restore();
+		$args           = auto_site_name( $args, 'site', __FUNCTION__ );
+		$backup_restore = new Site_Backup_Restore();
 		$backup_restore->restore( $args, $assoc_args );
 	}
 


### PR DESCRIPTION
This pull request updates the site backup logic to better handle backup requests when the site is disabled, especially for the `--list` and `--dash-auth` flags. The changes ensure that listing backups and EasyDash API callbacks work even if the site is disabled, and that appropriate error handling and messaging are in place for EasyDash integration.

**Improvements for handling site disabled state and EasyDash integration:**

* Modified how `get_site_info` is called: for `--list` and `--dash-auth` operations, it no longer requires the site to be enabled, allowing backup listing and EasyDash authentication to proceed even if the site is disabled.
* Added logic so that, when `--dash-auth` is used and the site is disabled, an API callback is sent with an error message, and a clear error is shown to the user. This ensures EasyDash receives the correct failure status.

**Code quality and user feedback improvements:**

* Ensured that EasyDash authentication properties are set before any error handling, so API callbacks function correctly in all error scenarios.
* Improved success messaging by explicitly notifying the user when a backup is created successfully.
* Refactored the handling of the `--dash-auth` flag to streamline validation and error reporting.