### PR TITLE
Enhancement: Enable support for containerized EasyEngine deployments

### DIFF
--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -764,19 +764,32 @@ function sysctl_parameters() {
 
 /**
  * Removes entry of the site from /etc/hosts
+ * Optimized for Docker environments to prevent Inode/Device busy errors.
  *
  * @param string $site_url site name.
- *
+ * @throws Exception If /etc/hosts cannot be read or written.
  */
 function remove_etc_hosts_entry( $site_url ) {
-	$fs = new Filesystem();
 
-	$hosts_file = file_get_contents( '/etc/hosts' );
+    // 1. Read /etc/hosts file; suppress warnings and handle failure manually
+    $hosts_file = @file_get_contents( '/etc/hosts' );
+    if ( $hosts_file === false ) {
+        throw new Exception( "Failed to read /etc/hosts" );
+    }
 
-	$site_url_escaped = preg_replace( '/\./', '\.', $site_url );
-	$hosts_file_new   = preg_replace( "/127\.0\.0\.1\s+$site_url_escaped\n/", '', $hosts_file );
+    // 2. Escape special characters in domain (e.g., dots) for regex safety
+    $site_url_escaped = preg_quote( $site_url, '/' );
 
-	$fs->dumpFile( '/etc/hosts', $hosts_file_new );
+    // 3. Remove the specific line matching the Localhost IP and the site URL
+    $hosts_file_new = preg_replace( "/127\.0\.0\.1\s+$site_url_escaped\n/", '', $hosts_file );
+
+    // 4. Overwrite file directly to maintain the Inode (fixes Docker mount issues)
+    // Using LOCK_EX to prevent race conditions during write
+    $result = file_put_contents( '/etc/hosts', $hosts_file_new, LOCK_EX );
+
+    if ( $result === false ) {
+        throw new Exception( "Failed to update /etc/hosts" );
+    }
 }
 
 /**


### PR DESCRIPTION
Description
This PR updates the /etc/hosts modification logic to ensure compatibility when EasyEngine is running inside a Docker container (Containerized CLI).

The Problem
Currently, EasyEngine uses Filesystem::dumpFile() (or similar atomic-write logic) which attempts to create a temporary file and rename it to /etc/hosts. In Docker environments where /etc/hosts is bind-mounted from the host machine, this operation fails with "Device or resource busy" because Docker does not allow changing the Inode of mounted system files.

The Solution
The logic has been updated to use direct stream writing via file_put_contents() with LOCK_EX.

Inode Preservation: By writing directly to the existing file, we preserve the Inode, allowing Docker to sync changes seamlessly between the container and the host.

Backwards Compatibility: This change is completely transparent to users running EasyEngine natively on Linux/macOS.

Robustness: Switched to preg_quote() for safer regex handling of site URLs.

Reference Case
This improvement is based on successful implementation in a containerized version of EasyEngine available here: [dinhngocdung/easyengine](https://hub.docker.com/r/dinhngocdung/easyengine). This image allows users to run EasyEngine as a standalone tool without native installation, and this PR upstreaming ensures the core logic supports this modern deployment method.

Changes
Modified remove_etc_hosts_entry() to use file_put_contents.

Improved regex patterns to be more resilient and documented in English.

Added explicit exception handling for better debugging in container environments.