### PR TITLE
fix: cap rclone backup/restore memory to prevent OOM kills

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -1271,9 +1271,61 @@ class Site_Backup_Restore {
 
 	private function rclone_download( $path ) {
 		$cpu_cores     = intval( EE::launch( 'nproc' )->stdout );
-		$multi_threads = min( intval( $cpu_cores ) * 2, 32 );
-		$command       = sprintf( "rclone copy -P --multi-thread-streams %d %s %s", $multi_threads, escapeshellarg( $this->get_remote_path( false ) ), escapeshellarg( $path ) );
-		$output        = EE::launch( $command );
+		$available_ram = intval( EE::launch( "free -m | grep Mem | awk '{print $7}'" )->stdout );
+
+		// Size download parallelism and read-ahead buffers (one --buffer-size
+		// buffer per --transfers) against available RAM, reusing the upload budget
+		// helper. The helper's S3 term models --s3-upload-concurrency multipart
+		// buffers, which downloads never allocate, so pass is_s3 = false here; the
+		// multi-thread download streams are budgeted separately below.
+		$res         = $this->compute_rclone_resources( $cpu_cores, $available_ram, false );
+		$transfers   = $res['transfers'];
+		$buffer_size = $res['buffer_size'] . 'M';
+
+		// On top of the read-ahead buffers, rclone splits large files into
+		// --multi-thread-streams concurrent download streams. Each stream holds a
+		// --multi-thread-write-buffer-size in-memory buffer (rclone default
+		// 128KiB) and pulls up to one --multi-thread-chunk-size range at a time,
+		// and every running --transfers can be multi-threaded at once, so the
+		// in-flight multi-thread footprint scales as:
+		//
+		//     transfers * multi_thread_streams * per_stream_mem
+		//
+		// The previous code set streams = min( cpu_cores * 2, 32 ) with no memory
+		// awareness and relied on rclone's default --transfers 4, so a many-core
+		// VM with little RAM (e.g. 4 GB) could fan out 4 * 32 = 128 streams and be
+		// OOM-killed during restore/rollback. It also produced
+		// --multi-thread-streams 0 when nproc returned empty. Cap the stream count
+		// so the combined multi-thread buffers fit the same memory budget used for
+		// upload, and floor it at 1.
+		$mt_write_buffer = max( 1, intval( get_config_value( 'rclone-mt-write-buffer-size', 128 ) ) ); // KiB; rclone default.
+		$mt_chunk_size   = max( 1, intval( get_config_value( 'rclone-mt-chunk-size', 64 ) ) );         // MB; rclone default.
+		$mem_fraction    = floatval( get_config_value( 'rclone-mem-fraction', 0.5 ) );
+		$mem_fraction    = min( 0.9, max( 0.1, $mem_fraction ) );
+		$budget          = (int) floor( max( 0, intval( $available_ram ) ) * $mem_fraction ); // MB.
+
+		// Per-stream in-memory cost (MB): the write buffer plus a single in-flight
+		// chunk range being read from the source.
+		$per_stream_mem = ( $mt_write_buffer / 1024 ) + $mt_chunk_size;
+
+		$mt_streams = max( 1, min( max( 1, intval( $cpu_cores ) ) * 2, 32 ) );
+		// Shrink streams until transfers * streams * per_stream_mem fits the
+		// budget, but never below 1 (a single stream still works, just slower).
+		while ( $mt_streams > 1 && ( $transfers * $mt_streams * $per_stream_mem ) > $budget ) {
+			$mt_streams--;
+		}
+
+		EE::debug( sprintf(
+			'rclone download tuning: available_ram=%dMB transfers=%d buffer-size=%s multi-thread-streams=%d (est. peak ~%dMB)',
+			$available_ram,
+			$transfers,
+			$buffer_size,
+			$mt_streams,
+			(int) ( ( $transfers * $res['buffer_size'] ) + ( $transfers * $mt_streams * $per_stream_mem ) )
+		) );
+
+		$command = sprintf( "rclone copy -P --transfers %d --checkers %d --buffer-size %s --multi-thread-streams %d --multi-thread-chunk-size %dM %s %s", $transfers, $transfers, $buffer_size, $mt_streams, $mt_chunk_size, escapeshellarg( $this->get_remote_path( false ) ), escapeshellarg( $path ) );
+		$output  = EE::launch( $command );
 
 		if ( $output->return_code ) {
 			EE::error( 'Error downloading backup from remote storage.' );

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -1284,22 +1284,32 @@ class Site_Backup_Restore {
 
 
 	private function rclone_upload( $path ) {
-		$cpu_cores       = intval( EE::launch( 'nproc' )->stdout );
-		$ram             = intval( EE::launch( "free -m | grep Mem | awk '{print $7}'" )->stdout );
-		$transfers       = max( 2, min( intval( $cpu_cores / 2 ), 4 ) );
-		$max_buffer_size = 4096;
+		$cpu_cores     = intval( EE::launch( 'nproc' )->stdout );
+		$available_ram = intval( EE::launch( "free -m | grep Mem | awk '{print $7}'" )->stdout );
 
+		// Detect S3 backends, which require additional multipart-upload tuning.
+		$rclone_type = EE::launch( 'rclone config show easyengine | grep type' )->stdout;
+		$is_s3       = ( strpos( $rclone_type, 's3' ) !== false );
 
-		$buffer_size = min( floor( $ram / $transfers ), $max_buffer_size ) . 'M';
+		$res         = $this->compute_rclone_resources( $cpu_cores, $available_ram, $is_s3 );
+		$transfers   = $res['transfers'];
+		$buffer_size = $res['buffer_size'] . 'M';
 
-
-		$command = 'rclone config show easyengine | grep type';
-		$output  = EE::launch( $command )->stdout;
 		$s3_flag = '';
-
-		if ( strpos( $output, 's3' ) !== false ) {
-			$s3_flag = ' --s3-chunk-size=64M --s3-upload-concurrency ' . min( intval( $cpu_cores ) * 2, 32 );
+		if ( $is_s3 ) {
+			$s3_flag = sprintf( ' --s3-chunk-size=%dM --s3-upload-concurrency %d', $res['s3_chunk_size'], $res['s3_concurrency'] );
 		}
+
+		EE::debug( sprintf(
+			'rclone upload tuning: available_ram=%dMB transfers=%d buffer-size=%s s3=%s s3-chunk-size=%dM s3-upload-concurrency=%d (est. peak ~%dMB)',
+			$available_ram,
+			$transfers,
+			$buffer_size,
+			$is_s3 ? 'yes' : 'no',
+			$res['s3_chunk_size'],
+			$res['s3_concurrency'],
+			$transfers * ( $res['buffer_size'] + ( $res['s3_chunk_size'] * $res['s3_concurrency'] ) )
+		) );
 
 		$command = sprintf( "rclone copy -P %s --transfers %d --checkers %d --buffer-size %s %s %s", $s3_flag, $transfers, $transfers, $buffer_size, escapeshellarg( $path ), escapeshellarg( $this->get_remote_path() ) );
 		$output  = EE::launch( $command );
@@ -1329,6 +1339,78 @@ class Site_Backup_Restore {
 				$this->cleanup_old_backups();
 			}
 		}
+	}
+
+	/**
+	 * Compute memory-safe rclone transfer settings for an upload.
+	 *
+	 * rclone allocates one `--buffer-size` read-ahead buffer per concurrent
+	 * `--transfers`, and, for S3 backends, an additional
+	 * `--s3-chunk-size * --s3-upload-concurrency` multipart buffer per transfer.
+	 * The total in-memory footprint is therefore:
+	 *
+	 *     transfers * ( buffer_size + s3_chunk_size * s3_upload_concurrency )
+	 *
+	 * The previous implementation set `buffer_size = available_ram / transfers`,
+	 * which made the read-ahead buffers alone consume ~100% of available memory
+	 * (e.g. `--buffer-size 1328M --transfers 2` on a 4 GB host) and routinely
+	 * triggered the OOM killer during backups. This helper instead caps rclone's
+	 * total footprint at a fraction of currently-available memory, while still
+	 * scaling parallelism and buffer size up on larger hosts so spare RAM is used.
+	 *
+	 * Tunable via global config: `rclone-mem-fraction` (default 0.5) and
+	 * `rclone-max-buffer-size` in MB (default 256).
+	 *
+	 * @param int  $cpu_cores     Number of CPU cores (nproc).
+	 * @param int  $available_ram Currently available memory in MB.
+	 * @param bool $is_s3         Whether the remote is an S3 backend.
+	 *
+	 * @return array{transfers:int,buffer_size:int,s3_concurrency:int,s3_chunk_size:int}
+	 */
+	private function compute_rclone_resources( $cpu_cores, $available_ram, $is_s3 ) {
+		$cpu_cores     = max( 1, intval( $cpu_cores ) );
+		$available_ram = max( 0, intval( $available_ram ) );
+
+		// Fraction of *available* RAM rclone may use, clamped to a safe range so
+		// a backup never starves the host (MariaDB, PHP-FPM, nginx) or itself.
+		$mem_fraction = floatval( get_config_value( 'rclone-mem-fraction', 0.5 ) );
+		$mem_fraction = min( 0.9, max( 0.1, $mem_fraction ) );
+
+		$min_buffer    = 16; // rclone's default; never go below it.
+		$max_buffer    = max( $min_buffer, intval( get_config_value( 'rclone-max-buffer-size', 256 ) ) );
+		$s3_chunk_size = $is_s3 ? 64 : 0;
+
+		// Total memory budget for rclone transfer/multipart buffers.
+		$budget = (int) floor( $available_ram * $mem_fraction );
+
+		// Desired parallelism, scaled with cores but capped to sane bounds.
+		$transfers      = max( 2, min( $cpu_cores, 8 ) );
+		$s3_concurrency = $is_s3 ? max( 2, min( $cpu_cores * 2, 32 ) ) : 0;
+
+		// If the budget can't fit the desired parallelism even at the minimum
+		// buffer size, first shrink S3 multipart concurrency (the biggest memory
+		// lever at 64M/chunk), then the number of parallel transfers.
+		while ( $is_s3 && $s3_concurrency > 2 &&
+			$transfers * ( $min_buffer + $s3_chunk_size * $s3_concurrency ) > $budget ) {
+			$s3_concurrency = max( 2, intval( $s3_concurrency / 2 ) );
+		}
+		while ( $transfers > 2 &&
+			$transfers * ( $min_buffer + $s3_chunk_size * $s3_concurrency ) > $budget ) {
+			$transfers--;
+		}
+
+		// Spend whatever budget remains after reserving S3 multipart buffers on
+		// the read-ahead buffer, clamped to [$min_buffer, $max_buffer].
+		$per_transfer_budget = intval( floor( $budget / $transfers ) );
+		$buffer_size         = $per_transfer_budget - ( $s3_chunk_size * $s3_concurrency );
+		$buffer_size         = max( $min_buffer, min( $buffer_size, $max_buffer ) );
+
+		return [
+			'transfers'      => $transfers,
+			'buffer_size'    => $buffer_size,
+			's3_concurrency' => $s3_concurrency,
+			's3_chunk_size'  => $s3_chunk_size,
+		];
 	}
 
 	/**

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -1316,9 +1316,20 @@ class Site_Backup_Restore {
 		$mt_chunk_size   = max( 1, intval( get_config_value( 'rclone-mt-chunk-size', 64 ) ) );         // MB; rclone default.
 		$per_stream_mem  = ( $mt_write_buffer / 1024 ) + $mt_chunk_size;                               // MB.
 
-		$per_transfer  = max( 1, intval( floor( $budget / $transfers ) ) );
-		$buffer_mb     = max( 16, min( intval( floor( $per_transfer / 2 ) ), $max_buffer ) );
-		$stream_budget = max( 0, $per_transfer - $buffer_mb );
+		// Reduce transfers until each transfer's share of the budget can hold the
+		// minimum read-ahead buffer plus at least one stream, so the combined
+		// footprint stays within budget whenever the budget allows it at all.
+		$min_per_transfer = 16 + (int) ceil( $per_stream_mem );
+		while ( $transfers > 1 && intval( floor( $budget / $transfers ) ) < $min_per_transfer ) {
+			$transfers--;
+		}
+		$per_transfer = max( $min_per_transfer, intval( floor( $budget / $transfers ) ) );
+
+		// Give the read-ahead buffer up to half the share (capped at $max_buffer)
+		// but always leave room for at least one stream; spend the rest on streams.
+		$buffer_mb     = min( intval( floor( $per_transfer / 2 ) ), $max_buffer, $per_transfer - (int) ceil( $per_stream_mem ) );
+		$buffer_mb     = max( 16, $buffer_mb );
+		$stream_budget = $per_transfer - $buffer_mb;
 		$mt_streams    = max( 1, min( $cpu_cores * 2, 32, intval( floor( $stream_budget / $per_stream_mem ) ) ) );
 		$buffer_size   = $buffer_mb . 'M';
 
@@ -1455,12 +1466,14 @@ class Site_Backup_Restore {
 
 		// If the budget can't fit the desired parallelism even at the minimum
 		// buffer size, first shrink S3 multipart concurrency (the biggest memory
-		// lever at 64M/chunk), then the number of parallel transfers.
-		while ( $is_s3 && $s3_concurrency > 2 &&
+		// lever at 64M/chunk), then the number of parallel transfers. Both may
+		// fall to 1 on extremely tight budgets so the helper honours its own cap
+		// whenever the budget allows it at all (the desired floor stays at 2).
+		while ( $is_s3 && $s3_concurrency > 1 &&
 			$transfers * ( $min_buffer + $s3_chunk_size * $s3_concurrency ) > $budget ) {
-			$s3_concurrency = max( 2, intval( $s3_concurrency / 2 ) );
+			$s3_concurrency = max( 1, intval( $s3_concurrency / 2 ) );
 		}
-		while ( $transfers > 2 &&
+		while ( $transfers > 1 &&
 			$transfers * ( $min_buffer + $s3_chunk_size * $s3_concurrency ) > $budget ) {
 			$transfers--;
 		}

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -1269,62 +1269,72 @@ class Site_Backup_Restore {
 	}
 
 
+	/**
+	 * Read currently-available memory in MB.
+	 *
+	 * Pins `LC_ALL=C` so the `Mem:` label and column layout stay stable across
+	 * locales, locates the "available" column by its header name (rather than a
+	 * fixed field index, which differs across `free`/procps versions) and falls
+	 * back to the "free" column on older builds that have no "available" column.
+	 *
+	 * @return int Available memory in MB (0 if it cannot be determined, in which
+	 *             case the resource helpers fall back to their safe minimums).
+	 */
+	private function get_available_ram_mb() {
+		$command = "LC_ALL=C free -m | awk 'NR==1{for(i=1;i<=NF;i++) if(\$i==\"available\") c=i+1} /^Mem:/{print (c ? \$c : \$4)}'";
+
+		return intval( EE::launch( $command )->stdout );
+	}
+
 	private function rclone_download( $path ) {
 		$cpu_cores     = intval( EE::launch( 'nproc' )->stdout );
-		$available_ram = intval( EE::launch( "free -m | grep Mem | awk '{print $7}'" )->stdout );
+		$available_ram = $this->get_available_ram_mb();
 
-		// Size download parallelism and read-ahead buffers (one --buffer-size
-		// buffer per --transfers) against available RAM, reusing the upload budget
-		// helper. The helper's S3 term models --s3-upload-concurrency multipart
-		// buffers, which downloads never allocate, so pass is_s3 = false here; the
-		// multi-thread download streams are budgeted separately below.
-		$res         = $this->compute_rclone_resources( $cpu_cores, $available_ram, false );
-		$transfers   = $res['transfers'];
-		$buffer_size = $res['buffer_size'] . 'M';
+		// Derive the memory-safe transfer count and the total RAM budget from the
+		// shared helper (is_s3 = false: downloads allocate no S3 multipart-upload
+		// buffers). The budget is reused below rather than recomputed.
+		$res        = $this->compute_rclone_resources( $cpu_cores, $available_ram, false );
+		$transfers  = $res['transfers'];
+		$budget     = $res['budget'];     // MB; available_ram * rclone-mem-fraction.
+		$max_buffer = $res['max_buffer']; // MB.
 
-		// On top of the read-ahead buffers, rclone splits large files into
-		// --multi-thread-streams concurrent download streams. Each stream holds a
-		// --multi-thread-write-buffer-size in-memory buffer (rclone default
-		// 128KiB) and pulls up to one --multi-thread-chunk-size range at a time,
-		// and every running --transfers can be multi-threaded at once, so the
-		// in-flight multi-thread footprint scales as:
+		// Per concurrent --transfers a download holds one --buffer-size read-ahead
+		// buffer plus, for files above rclone's --multi-thread-cutoff,
+		// --multi-thread-streams streams -- each with a
+		// --multi-thread-write-buffer-size buffer and one in-flight
+		// --multi-thread-chunk-size range. The whole footprint must fit ONE budget:
 		//
-		//     transfers * multi_thread_streams * per_stream_mem
+		//     transfers * ( buffer_size + multi_thread_streams * per_stream_mem ) <= budget
 		//
-		// The previous code set streams = min( cpu_cores * 2, 32 ) with no memory
-		// awareness and relied on rclone's default --transfers 4, so a many-core
-		// VM with little RAM (e.g. 4 GB) could fan out 4 * 32 = 128 streams and be
-		// OOM-killed during restore/rollback. It also produced
-		// --multi-thread-streams 0 when nproc returned empty. Cap the stream count
-		// so the combined multi-thread buffers fit the same memory budget used for
-		// upload, and floor it at 1.
+		// so each transfer's share of the budget is split between the read-ahead
+		// buffer (up to half, capped at $max_buffer) and the multi-thread streams.
+		// Both scale with available RAM; on a tight budget streams floor at 1. The
+		// previous code budgeted the streams against the full budget independently
+		// of the read-ahead buffers, so the two pools could together reach ~2x the
+		// intended fraction and still OOM during restore/rollback.
 		$mt_write_buffer = max( 1, intval( get_config_value( 'rclone-mt-write-buffer-size', 128 ) ) ); // KiB; rclone default.
 		$mt_chunk_size   = max( 1, intval( get_config_value( 'rclone-mt-chunk-size', 64 ) ) );         // MB; rclone default.
-		$mem_fraction    = floatval( get_config_value( 'rclone-mem-fraction', 0.5 ) );
-		$mem_fraction    = min( 0.9, max( 0.1, $mem_fraction ) );
-		$budget          = (int) floor( max( 0, intval( $available_ram ) ) * $mem_fraction ); // MB.
+		$per_stream_mem  = ( $mt_write_buffer / 1024 ) + $mt_chunk_size;                               // MB.
 
-		// Per-stream in-memory cost (MB): the write buffer plus a single in-flight
-		// chunk range being read from the source.
-		$per_stream_mem = ( $mt_write_buffer / 1024 ) + $mt_chunk_size;
-
-		$mt_streams = max( 1, min( max( 1, intval( $cpu_cores ) ) * 2, 32 ) );
-		// Shrink streams until transfers * streams * per_stream_mem fits the
-		// budget, but never below 1 (a single stream still works, just slower).
-		while ( $mt_streams > 1 && ( $transfers * $mt_streams * $per_stream_mem ) > $budget ) {
-			$mt_streams--;
-		}
+		$per_transfer  = max( 1, intval( floor( $budget / $transfers ) ) );
+		$buffer_mb     = max( 16, min( intval( floor( $per_transfer / 2 ) ), $max_buffer ) );
+		$stream_budget = max( 0, $per_transfer - $buffer_mb );
+		$mt_streams    = max( 1, min( $cpu_cores * 2, 32, intval( floor( $stream_budget / $per_stream_mem ) ) ) );
+		$buffer_size   = $buffer_mb . 'M';
 
 		EE::debug( sprintf(
-			'rclone download tuning: available_ram=%dMB transfers=%d buffer-size=%s multi-thread-streams=%d (est. peak ~%dMB)',
+			'rclone download tuning: available_ram=%dMB budget=%dMB transfers=%d buffer-size=%s multi-thread-streams=%d mt-write-buffer=%dKi mt-chunk-size=%dM (est. peak ~%dMB)',
 			$available_ram,
+			$budget,
 			$transfers,
 			$buffer_size,
 			$mt_streams,
-			(int) ( ( $transfers * $res['buffer_size'] ) + ( $transfers * $mt_streams * $per_stream_mem ) )
+			$mt_write_buffer,
+			$mt_chunk_size,
+			(int) ( $transfers * ( $buffer_mb + $mt_streams * $per_stream_mem ) )
 		) );
 
-		$command = sprintf( "rclone copy -P --transfers %d --checkers %d --buffer-size %s --multi-thread-streams %d --multi-thread-chunk-size %dM %s %s", $transfers, $transfers, $buffer_size, $mt_streams, $mt_chunk_size, escapeshellarg( $this->get_remote_path( false ) ), escapeshellarg( $path ) );
+		$command = sprintf( "rclone copy -P --transfers %d --buffer-size %s --multi-thread-streams %d --multi-thread-write-buffer-size %dKi --multi-thread-chunk-size %dM %s %s", $transfers, $buffer_size, $mt_streams, $mt_write_buffer, $mt_chunk_size, escapeshellarg( $this->get_remote_path( false ) ), escapeshellarg( $path ) );
 		$output  = EE::launch( $command );
 
 		if ( $output->return_code ) {
@@ -1337,7 +1347,7 @@ class Site_Backup_Restore {
 
 	private function rclone_upload( $path ) {
 		$cpu_cores     = intval( EE::launch( 'nproc' )->stdout );
-		$available_ram = intval( EE::launch( "free -m | grep Mem | awk '{print $7}'" )->stdout );
+		$available_ram = $this->get_available_ram_mb();
 
 		// Detect S3 backends, which require additional multipart-upload tuning.
 		$rclone_type = EE::launch( 'rclone config show easyengine | grep type' )->stdout;
@@ -1394,12 +1404,12 @@ class Site_Backup_Restore {
 	}
 
 	/**
-	 * Compute memory-safe rclone transfer settings for an upload.
+	 * Compute memory-safe rclone transfer settings shared by upload and download.
 	 *
 	 * rclone allocates one `--buffer-size` read-ahead buffer per concurrent
-	 * `--transfers`, and, for S3 backends, an additional
+	 * `--transfers`, and, for S3 uploads, an additional
 	 * `--s3-chunk-size * --s3-upload-concurrency` multipart buffer per transfer.
-	 * The total in-memory footprint is therefore:
+	 * The upload in-memory footprint is therefore:
 	 *
 	 *     transfers * ( buffer_size + s3_chunk_size * s3_upload_concurrency )
 	 *
@@ -1410,6 +1420,10 @@ class Site_Backup_Restore {
 	 * total footprint at a fraction of currently-available memory, while still
 	 * scaling parallelism and buffer size up on larger hosts so spare RAM is used.
 	 *
+	 * The returned `budget` (and `max_buffer`) let callers that allocate further
+	 * buffer pools -- e.g. `rclone_download()` sizing `--multi-thread-streams` --
+	 * stay within the same single budget instead of recomputing their own.
+	 *
 	 * Tunable via global config: `rclone-mem-fraction` (default 0.5) and
 	 * `rclone-max-buffer-size` in MB (default 256).
 	 *
@@ -1417,7 +1431,7 @@ class Site_Backup_Restore {
 	 * @param int  $available_ram Currently available memory in MB.
 	 * @param bool $is_s3         Whether the remote is an S3 backend.
 	 *
-	 * @return array{transfers:int,buffer_size:int,s3_concurrency:int,s3_chunk_size:int}
+	 * @return array{transfers:int,buffer_size:int,s3_concurrency:int,s3_chunk_size:int,budget:int,max_buffer:int}
 	 */
 	private function compute_rclone_resources( $cpu_cores, $available_ram, $is_s3 ) {
 		$cpu_cores     = max( 1, intval( $cpu_cores ) );
@@ -1462,6 +1476,8 @@ class Site_Backup_Restore {
 			'buffer_size'    => $buffer_size,
 			's3_concurrency' => $s3_concurrency,
 			's3_chunk_size'  => $s3_chunk_size,
+			'budget'         => $budget,
+			'max_buffer'     => $max_buffer,
 		];
 	}
 

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -1356,13 +1356,35 @@ class Site_Backup_Restore {
 	}
 
 
+	/**
+	 * Whether the configured rclone remote is an S3 backend.
+	 *
+	 * Resolves the remote name from `rclone-path` (instead of assuming
+	 * `easyengine`) and compares the backend's exact `type` value to `s3`,
+	 * rather than substring-matching the raw `rclone config show` output -- which
+	 * could both miss a non-`easyengine` remote and false-positive on any line
+	 * whose value merely contains the substring `s3`. All S3-compatible providers
+	 * (AWS, Spaces, Wasabi, MinIO, ...) share `type = s3`, so an exact match on
+	 * the type value covers them.
+	 *
+	 * @return bool
+	 */
+	private function is_s3_remote() {
+		$rclone_path = get_config_value( 'rclone-path', 'easyengine:easyengine' );
+		$remote      = explode( ':', $rclone_path )[0];
+
+		$command = sprintf( "rclone config show %s | awk -F '=' '/^[[:space:]]*type[[:space:]]*=/ {gsub(/[[:space:]]/, \"\", \$2); print \$2; exit}'", escapeshellarg( $remote ) );
+		$type    = trim( EE::launch( $command )->stdout );
+
+		return ( 's3' === $type );
+	}
+
 	private function rclone_upload( $path ) {
 		$cpu_cores     = intval( EE::launch( 'nproc' )->stdout );
 		$available_ram = $this->get_available_ram_mb();
 
 		// Detect S3 backends, which require additional multipart-upload tuning.
-		$rclone_type = EE::launch( 'rclone config show easyengine | grep type' )->stdout;
-		$is_s3       = ( strpos( $rclone_type, 's3' ) !== false );
+		$is_s3 = $this->is_s3_remote();
 
 		$res         = $this->compute_rclone_resources( $cpu_cores, $available_ram, $is_s3 );
 		$transfers   = $res['transfers'];


### PR DESCRIPTION
## Summary

EasyEngine's rclone-based backup and restore sized `--buffer-size` and parallelism from available RAM in a way that ignored how rclone actually allocates memory, so a single backup could consume ~100% of available RAM and get OOM-killed. This was observed in production on a 4 GB Oracle Cloud host running 6 WordPress sites (rclone killed mid-backup after consuming ~1.7 GB RSS). This PR replaces the ad-hoc sizing with a shared memory-budget helper that caps rclone's *total* in-memory footprint at a configurable fraction of currently-available RAM, scaling parallelism and buffers **up** on large hosts and **down** on constrained ones.

## Root cause

rclone does not allocate one buffer for the whole transfer. It allocates buffers **per running transfer**, so memory is multiplied by `--transfers`:

- **Upload.** rclone allocates one `--buffer-size` read-ahead buffer **per `--transfers`**, and for S3 backends an additional `--s3-chunk-size × --s3-upload-concurrency` multipart buffer per transfer. The old code set `buffer_size = available_ram / transfers`, so the read-ahead buffers alone summed back to ~100% of available RAM: `transfers × (available_ram / transfers) = available_ram`. On the Oracle box this produced `--buffer-size 1328M --transfers 2` → `2 × 1328M = 2656 MB` of read-ahead buffers, i.e. essentially all available memory, **before** the S3 multipart buffers were even counted. With MariaDB, Redis, PHP-FPM and nginx already resident, this saturated RAM and the kernel OOM-killed rclone. (Logged buffer sizes across the 6 sites ranged 1023M–1328M.)

- **Download / rollback.** `rclone_download()` ran `rclone copy -P --multi-thread-streams min(cpu*2, 32)` with no memory awareness and relied on rclone's default `--transfers 4`. For large files rclone fans out up to `transfers × multi-thread-streams` concurrent download streams, each holding a `--multi-thread-write-buffer-size` buffer plus one in-flight `--multi-thread-chunk-size` range. A many-core host could therefore spawn `4 × 32 = 128` concurrent streams and be OOM-killed during restore/rollback. An empty `nproc` reading also produced the degenerate `--multi-thread-streams 0`. The initial download fix bounded the stream count, but sized the read-ahead buffers and the multi-thread streams against the full budget *independently*, so the two pools could together reach ~2× the intended fraction (e.g. ~3.5 GB on an 8-core/4 GB host) and still OOM — now corrected by splitting one shared budget between them.

## Changes

- **`fix(backup): cap rclone upload memory to prevent OOM kills`** — introduces `compute_rclone_resources( $cpu_cores, $available_ram, $is_s3 )`, which budgets rclone's total footprint `transfers × (buffer_size + s3_chunk_size × s3_concurrency)` against a fraction of available RAM (default 50%, clamped 10–90%). It scales parallelism with cores (`transfers` 2–8), and on a constrained host first shrinks S3 multipart concurrency (the largest lever at 64M/chunk) and then `--transfers` until the budget fits, with `--buffer-size` clamped to `[16M, 256M]`. `rclone_upload()` now calls the helper and logs an `EE::debug` "rclone upload tuning" line with the chosen values and estimated peak.

- **`fix(restore): cap rclone download streams and transfers to available memory`** — `rclone_download()` now reuses `compute_rclone_resources()` with `is_s3 = false` (S3 multipart concurrency does not apply to downloads) to derive memory-safe `--transfers`, `--checkers` and `--buffer-size`, then caps `--multi-thread-streams` so that `transfers × streams × per_stream_mem` fits the same available-RAM budget, flooring at 1 (which also fixes the `nproc → 0` degenerate case). Per-stream cost is modeled from rclone's real levers `--multi-thread-write-buffer-size` and `--multi-thread-chunk-size`, and an `EE::debug` "rclone download tuning" line logs the chosen values and estimated peak.

- **`fix(backup): bound rclone memory within one budget and harden RAM detection`** — review follow-up to the two fixes above. The download read-ahead buffers and the multi-thread streams were each sized against the full mem-fraction budget independently, so the combined footprint could reach ~2× the intended fraction (e.g. ~3.5 GB on an 8-core/4 GB host) and still OOM; `rclone_download()` now splits **one** shared budget — `transfers × (buffer + streams × per_stream_mem) ≤ budget` by construction — between the read-ahead buffer (up to half per transfer, capped at `max_buffer`) and the streams, while still scaling streams up on memory-rich hosts. The brittle `free -m | grep Mem | awk '{print $7}'` probe (English-locale + fixed-column) is replaced by a `get_available_ram_mb()` helper that pins `LC_ALL=C` and locates the *available* column by header name (falling back to *free* on older free/procps), now used by both upload and download. The download command now actually emits `--multi-thread-write-buffer-size` (previously the `rclone-mt-write-buffer-size` knob only fed the memory model and had no effect on rclone) and no longer forces `--checkers` (it returns to rclone's default of 8 instead of being bound to the memory-derived transfer count, which needlessly throttled the compare phase). Finally `compute_rclone_resources()` now returns `budget` and `max_buffer` so the download consumes them instead of recomputing the budget formula.

## Behavior / impact

Peaks below are derived from the helper logic. The Oracle row uses the production case (1 core, ~2656 MB available — the same value that produced the old `1328M` buffer), and the large-host row shows resources still scale up.

### Upload

| Host | Old | New |
|---|---|---|
| Oracle 1 core / ~2656 MB avail (S3) | `--buffer-size 1328M --transfers 2` → read-ahead peak **~2656 MB** (≈100% of available → **OOM**), plus S3 multipart on top | `--transfers 2 --buffer-size 256M --s3-upload-concurrency 2` → peak **~768 MB** (~29%) |
| Oracle 1 core / ~2656 MB avail (non-S3) | as above | `--transfers 2 --buffer-size 256M` → peak **~512 MB** |
| 16 core / 24 GB avail (S3) | `--transfers 4 --buffer-size 4096M` (capped) → read-ahead peak ~16 GB | `--transfers 8 --buffer-size 256M --s3-upload-concurrency 16` → peak **~10240 MB** (within 50% budget) |
| 16 core / 24 GB avail (non-S3) | as above | `--transfers 8 --buffer-size 256M` → peak **~2048 MB** |

### Download

| Host | Old | New |
|---|---|---|
| Oracle 1 core / ~2656 MB avail | default `--transfers 4` × `--multi-thread-streams 2` = up to **8** streams, memory-unaware | `--transfers 2 --buffer-size 256M --multi-thread-streams 2` → peak **~768 MB** |
| 8 core / ~4000 MB avail | default `--transfers 4` × `--multi-thread-streams 16` = up to **64** streams, memory-unaware | `--transfers 8 --buffer-size 125M --multi-thread-streams 1` → peak **~1513 MB** (the read-ahead/stream double-spend that previously pushed this to ~3.5 GB is now fixed) |
| 16 core / 24 GB avail | default `--transfers 4` × `--multi-thread-streams 32` = up to **128** concurrent streams | `--transfers 8 --buffer-size 256M --multi-thread-streams 19` → peak **~11.8 GB** (within the 12 GB budget — streams scale up to use spare RAM) |
| `nproc` returns empty | `--multi-thread-streams 0` (degenerate) | floored to `--multi-thread-streams 1` |

The download command now also emits `--multi-thread-write-buffer-size` and `--multi-thread-chunk-size` (so the memory model matches the process), and no longer forces `--checkers` — it returns to rclone's default of 8 instead of being tied to the memory-derived transfer count.

Net effect: on the constrained Oracle host the backup/restore footprint drops from ~all available RAM to under a third of it, eliminating the OOM kill; on large-memory hosts parallelism and buffers scale up so spare RAM is still utilized.

## Configuration

All knobs are optional global config values read via `get_config_value()` and default to rclone's own defaults, so existing installs need no changes.

| Config key | Default | Effect |
|---|---|---|
| `rclone-mem-fraction` | `0.5` | Fraction of currently-available RAM rclone's total footprint may use, clamped to `[0.1, 0.9]`. Applies to both upload and download. |
| `rclone-max-buffer-size` | `256` (MB) | Upper clamp on `--buffer-size`. Lower bound is fixed at rclone's 16M default. |
| `rclone-mt-write-buffer-size` | `128` (KiB) | Per-download-stream write buffer (`--multi-thread-write-buffer-size`). Used to budget the stream count and now also passed through to rclone (previously it only fed the memory model and had no effect on the process). |
| `rclone-mt-chunk-size` | `64` (MB) | Per-download-stream in-flight chunk range (`--multi-thread-chunk-size`), used both to budget streams and passed to rclone. |

## Testing

- `php -l src/helper/Site_Backup_Restore.php` passes (no syntax errors).
- Budget math was verified against the helper logic for the Oracle (1 core / ~2656 MB) and a large (16 core / 24 GB) profile; figures in the tables above are reproduced from that logic.

Suggested maintainer validation:

1. Run a backup and a restore/rollback on a low-RAM host (e.g. a 4 GB VM) and inspect the new `EE::debug` lines (`ee --debug ...`): "rclone upload tuning: ..." and "rclone download tuning: ..." should report a sane `transfers`, a `buffer-size` within `[16M, 256M]`, and an estimated peak well under available RAM. The download line now also reports the shared `budget` and the chosen `mt-write-buffer` / `mt-chunk-size`, which should match the flags actually passed to rclone.
2. Confirm rclone is no longer OOM-killed (`dmesg -T | grep -i oom`, `journalctl -k | grep -i oom`) and that the backup/restore completes.
3. On a large-memory host, confirm the debug line shows higher `transfers` and stream counts so throughput is preserved.
4. Optionally set `rclone-mem-fraction` lower/higher and confirm the chosen values move accordingly.

## Risk / compatibility

- The download command now passes `--multi-thread-chunk-size` and `--multi-thread-write-buffer-size`, both available in modern rclone (the version EasyEngine installs); `--multi-thread-streams` was already in use. It no longer forces `--checkers` on download, reverting to rclone's default of 8.
- The available-RAM probe now pins `LC_ALL=C` and locates the *available* column by header name (with a *free*-column fallback for older free/procps), so it is no longer dependent on the system locale or column order.
- Otherwise backward compatible: all four config knobs are optional and default to rclone's own defaults, so behavior changes only in the direction of staying within a memory budget. No public command, flag, or stored configuration changes.
