### PR TITLE
fix(backup): make EasyDash backup callback flow consistent

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -41,6 +41,7 @@ class Site_Backup_Restore {
 	private $dash_api_url;
 	private $dash_backup_metadata;
 	private $dash_backup_completed = false;
+	private $dash_callback_sent = false; // Guard: exactly one terminal callback (success XOR failure) may be emitted
 	private $dash_new_backup_path; // Track new backup path for potential rollback
 
 	// Error tracking for EasyDash failure callbacks
@@ -154,8 +155,6 @@ class Site_Backup_Restore {
 
 		$this->fs->remove( EE_BACKUP_DIR . '/' . $this->site_data['site_url'] . '.lock' );
 
-		// Mark backup as completed and send success callback
-		$this->dash_backup_completed = true;
 		if ( $this->dash_auth_enabled ) {
 			$api_success = $this->send_dash_success_callback(
 				$this->dash_api_url,
@@ -164,13 +163,27 @@ class Site_Backup_Restore {
 				$this->dash_backup_metadata
 			);
 
-			// Only cleanup old backups if API callback succeeded
-			// If API failed, rollback the newly uploaded backup
 			if ( $api_success ) {
+				// Backup is now registered with EasyDash; only then is it safe to
+				// mark complete (suppressing the shutdown failure callback) and prune.
+				$this->dash_backup_completed = true;
 				$this->cleanup_old_backups();
 			} else {
+				// Success callback failed: the upload is orphaned (EasyDash never
+				// recorded it), so roll it back and report failure. dash_backup_completed
+				// stays false so the shutdown handler emits the single failure callback;
+				// EE::error() makes the exit code/message reflect that no backup remains.
+				$this->capture_error(
+					'Backup uploaded but EasyDash success callback failed; rolled back the orphaned upload.',
+					self::ERROR_TYPE_NETWORK,
+					4002
+				);
 				$this->rollback_failed_backup();
+				EE::error( 'EasyDash success callback failed; the uploaded backup was rolled back. No backup was created.' );
 			}
+		} else {
+			// Non-dash path: backup is done once the upload succeeds.
+			$this->dash_backup_completed = true;
 		}
 
 		// Release global backup lock (also released by shutdown handler as safety net)
@@ -189,8 +202,9 @@ class Site_Backup_Restore {
 	 * explicitly captured during backup execution.
 	 */
 	public function dash_shutdown_handler() {
-		// Only send failure callback if dash auth was enabled and backup didn't complete
-		if ( $this->dash_auth_enabled && ! $this->dash_backup_completed ) {
+		// Only send a failure callback if dash auth was enabled, the backup didn't
+		// complete, and no terminal callback (success or failure) has been sent yet.
+		if ( $this->dash_auth_enabled && ! $this->dash_backup_completed && ! $this->dash_callback_sent ) {
 
 			// If no error was captured yet, try to capture shutdown error
 			if ( empty( $this->dash_error_message ) ) {
@@ -1635,10 +1649,16 @@ class Site_Backup_Restore {
 		$result = EE::launch( sprintf( 'rclone purge %s', escapeshellarg( $this->dash_new_backup_path ) ) );
 
 		if ( $result->return_code ) {
-			EE::warning( sprintf(
-				'Failed to delete backup from remote storage. Please manually delete: %s',
+			// Rollback purge failed: an untracked backup is now orphaned on the
+			// remote. Surface it so the exit code and failure callback reflect this
+			// state instead of silently continuing past a warning. capture_error keeps
+			// the root cause if one was already recorded by the caller.
+			$message = sprintf(
+				'Failed to delete orphaned backup from remote storage. Please manually delete: %s',
 				$this->dash_new_backup_path
-			) );
+			);
+			$this->capture_error( $message, self::ERROR_TYPE_FILESYSTEM, 4003 );
+			EE::error( $message );
 		} else {
 			EE::success( 'Successfully removed unregistered backup from remote storage.' );
 		}
@@ -1727,7 +1747,15 @@ class Site_Backup_Restore {
 
 		EE::debug( 'Payload being sent: ' . json_encode( $payload ) );
 
-		return $this->send_dash_request( $endpoint, $payload );
+		$success = $this->send_dash_request( $endpoint, $payload );
+
+		// A success that actually reached EasyDash is the terminal callback; a failed
+		// attempt is not, so the failure path can still emit the failure callback.
+		if ( $success ) {
+			$this->dash_callback_sent = true;
+		}
+
+		return $success;
 	}
 
 	/**
@@ -1756,6 +1784,9 @@ class Site_Backup_Restore {
 				'error_code'    => $payload['error_code'],
 			] ) );
 
+		// Failure is terminal: mark before sending so a concurrent shutdown pass
+		// can never emit a second (duplicate) terminal callback.
+		$this->dash_callback_sent = true;
 		$this->send_dash_request( $endpoint, $payload );
 	}
 

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -176,7 +176,7 @@ class Site_Backup_Restore {
 				$this->capture_error(
 					'Backup uploaded but EasyDash success callback failed; rolled back the orphaned upload.',
 					self::ERROR_TYPE_NETWORK,
-					4002
+					4004
 				);
 				$this->rollback_failed_backup();
 				EE::error( 'EasyDash success callback failed; the uploaded backup was rolled back. No backup was created.' );
@@ -1649,18 +1649,21 @@ class Site_Backup_Restore {
 		$result = EE::launch( sprintf( 'rclone purge %s', escapeshellarg( $this->dash_new_backup_path ) ) );
 
 		if ( $result->return_code ) {
-			// Rollback purge failed: an untracked backup is now orphaned on the
-			// remote. Surface it so the exit code and failure callback reflect this
-			// state instead of silently continuing past a warning. capture_error keeps
-			// the root cause if one was already recorded by the caller.
+			// Rollback purge failed: the untracked backup genuinely survives on the
+			// remote, so the operator must delete it manually. Force-overwrite any
+			// optimistic "rolled back" error captured by the caller (capture_error is
+			// first-wins) so EasyDash receives this accurate path, not the inverse.
 			$message = sprintf(
 				'Failed to delete orphaned backup from remote storage. Please manually delete: %s',
 				$this->dash_new_backup_path
 			);
+			$this->dash_error_message = '';
 			$this->capture_error( $message, self::ERROR_TYPE_FILESYSTEM, 4003 );
 			EE::error( $message );
 		} else {
-			EE::success( 'Successfully removed unregistered backup from remote storage.' );
+			// Demoted from EE::success: this always precedes a terminal EE::error, so a
+			// green success line would be misleading on a failing command.
+			EE::log( 'Successfully removed unregistered backup from remote storage.' );
 		}
 	}
 


### PR DESCRIPTION
## Summary

Makes the EasyDash (`--dash-auth`) backup callback flow consistent, so the command's exit status, the console message, and the callback EasyDash receives all agree with what actually happened.

## Bugs fixed

1. **False success after rollback.** When the upload succeeded but the EasyDash success callback failed, `rollback_failed_backup()` deleted the just-uploaded backup, yet the command still printed `EE::success('Backup created successfully.')` and exited 0. It now captures the error, rolls back, and `EE::error`s — accurate non-zero exit + message.
2. **Suppressed failure callback.** `dash_backup_completed` was set `true` *before* the success callback, so a failed callback also suppressed the shutdown failure callback → EasyDash was told neither success nor failure. It is now set only after a *confirmed* success callback (and on the non-dash path), so the failure callback fires.
3. **At-most-one terminal callback.** New `dash_callback_sent` guard, set at the real send sites and checked by the shutdown handler — exactly one terminal callback (success XOR failure), never zero, never double.
4. **Orphan signal on purge failure.** If the rollback `rclone purge` also fails (the orphan survives on remote), EasyDash now receives the accurate "manually delete `<path>`" message (code `4003`) instead of the optimistic "rolled back" one — `capture_error` is first-wins, so the purge-failure branch force-overwrites it.

Also: the new callback-failure uses code `4004` (avoids colliding with the existing `4002` "Database backup failed"); the rollback-success notice is demoted `EE::success`→`EE::log` (it always precedes a terminal error).

## Verification

Reviewed by two independent reviewers (correctness + design lenses). Both confirmed **exactly one** terminal callback across every path (success/callback-fail/purge-fail/pre-upload-abort/fatal/non-dash), verified via truth table + a PHP simulation of the exit/shutdown/`capture_error` behavior. Their two must-fixes (the `4002` collision and the orphan-payload override) are incorporated.
