### PR TITLE
fix(backup): verify DB dump and archive integrity to prevent silent corrupt backups

### DIFF
--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -463,6 +463,10 @@ class Site_Backup_Restore {
 			// This is optional, so we just log a warning instead of failing
 			if ( $result->return_code >= 2 ) {
 				EE::warning( 'Failed to backup custom docker-compose directory. Continuing with backup.' );
+			} elseif ( EE::launch( sprintf( '7z t %s', escapeshellarg( $custom_docker_compose_dir_archive ) ) )->return_code >= 2 ) {
+				// Optional archive: warn (and drop the corrupt zip) instead of aborting the whole backup.
+				EE::warning( 'Custom docker-compose archive failed integrity check. Excluding it from the backup.' );
+				$this->fs->remove( $custom_docker_compose_dir_archive );
 			}
 		}
 	}
@@ -502,7 +506,8 @@ class Site_Backup_Restore {
 	 * @param string $archive Absolute path to the archive to test.
 	 */
 	private function verify_archive_integrity( $archive ) {
-		if ( EE::exec( sprintf( '7z t %s', escapeshellarg( $archive ) ) ) ) {
+		// 7z exit codes: 0=success, 1=warning (non-fatal), 2+=fatal error.
+		if ( EE::launch( sprintf( '7z t %s', escapeshellarg( $archive ) ) )->return_code < 2 ) {
 			return;
 		}
 
@@ -618,6 +623,8 @@ class Site_Backup_Restore {
 			);
 			EE::error( 'Failed to create nginx configuration backup archive. Please check disk space and file permissions.' );
 		}
+
+		$this->verify_archive_integrity( $backup_file );
 	}
 
 	private function backup_php_conf( $backup_dir ) {
@@ -638,6 +645,8 @@ class Site_Backup_Restore {
 			);
 			EE::error( 'Failed to create PHP configuration backup archive. Please check disk space and file permissions.' );
 		}
+
+		$this->verify_archive_integrity( $backup_file );
 	}
 
 	private function backup_html( $backup_dir ) {
@@ -680,7 +689,10 @@ class Site_Backup_Restore {
 
 		$this->fs->mkdir( $backup_dir . '/sql' );
 
-		// Escape DB credentials: command runs through a container shell (matches restore_db()/get_db_size()).
+		// Best-effort layer-1 quoting of DB credentials (consistent with restore_db()/get_db_size()).
+		// NOTE: the value still passes through a second double-quoted `bash -c "$command"` layer
+		// inside `ee shell` that escapeshellarg cannot protect, so a password containing ` " or $
+		// can still break the dump. Fully hardening that inner wrapper is out of scope here.
 		$backup_command = sprintf(
 			'mysqldump --skip-ssl -u %s -p%s -h %s --single-transaction %s > /var/www/htdocs/%s',
 			escapeshellarg( $db_user ),
@@ -707,7 +719,19 @@ class Site_Backup_Restore {
 			EE::error( 'Database backup failed. Please check database credentials and connectivity.' );
 		}
 
-		EE::exec( sprintf( 'mv %s %s', $sql_dump_path, $sql_file ) );
+		// A failed mv (cross-device, permissions, disk-full, etc.) would leave sql/ empty;
+		// `7z u` on an empty dir exits 0 and `7z t` passes, shipping a DB-less "successful"
+		// backup. Fail loudly unless the dump actually landed and is non-empty.
+		if ( ! EE::exec( sprintf( 'mv %s %s', escapeshellarg( $sql_dump_path ), escapeshellarg( $sql_file ) ) )
+			|| ! $this->fs->exists( $sql_file ) || filesize( $sql_file ) <= 0 ) {
+			$this->capture_error(
+				sprintf( 'Failed to stage database dump for database: %s', $db_name ),
+				self::ERROR_TYPE_DATABASE,
+				4003
+			);
+			EE::error( 'Database backup failed while staging the dump file.' );
+		}
+
 		$backup_command = sprintf( 'cd %s && 7z u -mx=1 %s sql', $backup_dir, $backup_file );
 
 		$result = EE::launch( $backup_command );

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -689,7 +689,7 @@ class Site_Backup_Restore {
 
 		$this->fs->mkdir( $backup_dir . '/sql' );
 
-		// Best-effort layer-1 quoting of DB credentials (consistent with restore_db()/get_db_size()).
+		// Best-effort layer-1 quoting of DB credentials (consistent with get_db_size()).
 		// NOTE: the value still passes through a second double-quoted `bash -c "$command"` layer
 		// inside `ee shell` that escapeshellarg cannot protect, so a password containing ` " or $
 		// can still break the dump. Fully hardening that inner wrapper is out of scope here.

--- a/src/helper/Site_Backup_Restore.php
+++ b/src/helper/Site_Backup_Restore.php
@@ -488,7 +488,30 @@ class Site_Backup_Restore {
 			EE::error( 'Failed to create backup archive. Please check disk space and file permissions.' );
 		}
 
+		$this->verify_archive_integrity( $backup_file );
+
 		return $backup_file;
+	}
+
+	/**
+	 * Run `7z t` on a freshly-created backup archive and abort if it is corrupt.
+	 *
+	 * Catches silently-truncated/corrupt archives before they are uploaded, so a
+	 * broken backup never replaces a good one in remote storage.
+	 *
+	 * @param string $archive Absolute path to the archive to test.
+	 */
+	private function verify_archive_integrity( $archive ) {
+		if ( EE::exec( sprintf( '7z t %s', escapeshellarg( $archive ) ) ) ) {
+			return;
+		}
+
+		$this->capture_error(
+			sprintf( 'Backup archive failed integrity check: %s', $archive ),
+			self::ERROR_TYPE_FILESYSTEM,
+			3003
+		);
+		EE::error( 'Backup archive failed integrity verification. Aborting before upload to avoid overwriting a good backup.' );
 	}
 
 	private function backup_wp_content_dir( $backup_dir ) {
@@ -571,6 +594,8 @@ class Site_Backup_Restore {
 			);
 			EE::error( 'Failed to create backup archive. Please check disk space and file permissions.' );
 		}
+
+		$this->verify_archive_integrity( $backup_file );
 
 		return $backup_file;
 	}
@@ -655,17 +680,25 @@ class Site_Backup_Restore {
 
 		$this->fs->mkdir( $backup_dir . '/sql' );
 
-		$backup_command = sprintf( 'mysqldump --skip-ssl -u %s -p%s -h %s --single-transaction %s > /var/www/htdocs/%s', $db_user, $db_password, $db_host, $db_name, $sql_filename );
-		$args           = [ 'shell', $this->site_data['site_url'] ];
-		$assoc_args     = [ 'command' => $backup_command ];
-		$options        = [ 'skip-tty' => true ];
+		// Escape DB credentials: command runs through a container shell (matches restore_db()/get_db_size()).
+		$backup_command = sprintf(
+			'mysqldump --skip-ssl -u %s -p%s -h %s --single-transaction %s > /var/www/htdocs/%s',
+			escapeshellarg( $db_user ),
+			escapeshellarg( $db_password ),
+			escapeshellarg( $db_host ),
+			escapeshellarg( $db_name ),
+			$sql_filename
+		);
 
-		EE::run_command( $args, $assoc_args, $options );
+		// Launch via `ee shell` so the dump's exit code is captured. The shell `>` redirect
+		// creates/truncates the target before mysqldump runs, so a failed dump leaves a 0-byte
+		// file that passes exists(); rely on the exit code + filesize instead.
+		$dump_result = EE::launch( sprintf( 'ee shell %s --skip-tty --command=%s', escapeshellarg( $this->site_data['site_url'] ), escapeshellarg( $backup_command ) ) );
 
 		$sql_dump_path = EE_ROOT_DIR . '/sites/' . $this->site_data['site_url'] . '/app/htdocs/' . $sql_filename;
 
-		// Check if database dump was created successfully
-		if ( ! $this->fs->exists( $sql_dump_path ) ) {
+		// A 0-byte or missing dump, or a non-zero exit, means the backup failed.
+		if ( 0 !== $dump_result->return_code || ! $this->fs->exists( $sql_dump_path ) || filesize( $sql_dump_path ) <= 0 ) {
 			$this->capture_error(
 				sprintf( 'Database backup failed for database: %s', $db_name ),
 				self::ERROR_TYPE_DATABASE,


### PR DESCRIPTION
## Summary

Closes three silent-data-loss holes in the backup path so a failed/corrupt backup can never upload as "successful" and overwrite a good one.

## Fixes

1. **`mysqldump` failure produced a silent empty backup.** The dump runs via a shell `>` redirect, which truncates/creates the target *before* mysqldump runs — so a failed dump left a 0-byte file that passed the old `fs->exists()`-only check, got archived, and uploaded as success (after which `cleanup_old_backups()` could prune the good ones). The dump now runs via `EE::launch('ee shell … --command=…')` so its exit code is captured (`EE::run_command()` returns void and couldn't), and is validated by **`return_code === 0` AND `exists` AND `filesize > 0`**.
2. **Unchecked `mv` could ship a database-less backup.** After the dump, the staging `mv` into `sql/` was unchecked; if it failed (cross-device, permissions, disk-full, …), `sql/` was left empty, `7z u` on an empty dir exits 0, and `7z t` passed — a backup with **no database** shipping as success. The `mv` result is now checked and the destination asserted (`exists` + `filesize > 0`) before archiving.
3. **No archive integrity verification before upload.** A new `verify_archive_integrity()` runs `7z t` (treating exit ≥ 2 as failure, so a non-fatal 7z *warning* doesn't abort) on every archive `rclone_upload()` ships — the primary `<site>.zip`, `conf.zip` (nginx + php), and the optional custom-docker-compose zip (warn-and-exclude, preserving its optional semantics) — aborting before upload if any is corrupt.

Plus: DB credentials are `escapeshellarg()`-quoted in the mysqldump command (matching `restore_db()`/`get_db_size()`); the comment notes this is best-effort layer-1 quoting (the inner `ee shell` `bash -c "…"` layer still can't carry arbitrary `` ` ``/`"`/`$`).

## Verification

`php -l` passes. Reviewed by two independent reviewers (correctness + design); both empirically confirmed in containers that `ee shell --command` propagates the inner exit code, that a failed `mv`/empty `sql/` slips past `7z t` (the merge-blocker, now fixed), and that the exit-code check catches mid-stream mysqldump failures (OOM→137, lost-connection→3, disk-full→5).

## Merge note

Built on `develop` independently of the EasyDash callback PR (#481); both happened to introduce error code `4003` for different failures, so whichever merges second should renumber its `4003` to a free code (trivial). This PR's `4003` = "database dump failed to stage" (`ERROR_TYPE_DATABASE`).
