### PR TITLE
fix(ssl): correct misleading renewal-threshold log message

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -601,7 +601,7 @@ class Site_Letsencrypt {
 
 				\EE::log(
 					sprintf(
-						'Current certificate will expire in less than 25 days (%s), renewal is required.',
+						'Current certificate will expire in less than 35 days (%s), renewal is required.',
 						$parsedCertificate->getValidTo()->format( 'Y-m-d H:i:s' )
 					)
 				);


### PR DESCRIPTION
## Problem
During certificate renewal, `Site_Letsencrypt::executeRenewal()` logs:
> Current certificate will expire in less than 25 days (...), renewal is required.

But the threshold that triggers this branch is **35 days** — `$parsedCertificate->getValidTo()->format('U') - time() >= 3024000` (and `3024000s = 35 days`, per the comment right above it). The "25 days" wording understates the renewal window by 10 days and misleads operators about how urgent the renewal is.

## Fix
Correct the message to "less than 35 days" so it matches the 35-day threshold directly above it. Pure log-text fix — no logic or threshold change.
