### PR TITLE
fix(ssl): include ACME error message in operator-facing warnings

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -405,7 +405,7 @@ class Site_Letsencrypt {
 					$authorizationChallengeToCleanup[] = $authorizationChallenge;
 				} catch ( \Exception $e ) {
 					\EE::debug( $e->getMessage() );
-					\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
+					\EE::warning( 'Challenge Authorization failed (' . $e->getMessage() . '). Check logs and check if your domain is pointed correctly to this server.' );
 
 					$site_name = $domains[0];
 					$site_name = str_replace( '*.', '', $site_name );
@@ -641,18 +641,14 @@ class Site_Letsencrypt {
 			return true;
 
 		} catch ( \Exception $e ) {
-			\EE::warning( 'A critical error occured during certificate renewal' );
+			\EE::warning( 'A critical error occurred during certificate renewal: ' . $e->getMessage() );
 			\EE::debug( print_r( $e, true ) );
-
-			\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
 			\EE::log( 'You can fix the issue and re-run: ee site ssl-verify ' . $domains[0] );
 
 			return false;
 		} catch ( \Throwable $e ) {
-			\EE::warning( 'A critical error occured during certificate renewal' );
+			\EE::warning( 'A critical error occurred during certificate renewal: ' . $e->getMessage() );
 			\EE::debug( print_r( $e, true ) );
-
-			\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
 			\EE::log( 'You can fix the issue and re-run: ee site ssl-verify ' . $domains[0] );
 
 			return false;


### PR DESCRIPTION
## Problem
SSL issuance/renewal failures logged the real exception only via `EE::debug()` and showed operators a generic `EE::warning()`. Renewal runs unattended (cron) **without** `--debug`, so the actual ACME error (rate-limit reason, `badNonce`, `accountDoesNotExist`, a finalize/storage failure, etc.) — the single most useful diagnostic — was lost.

Separately, both `executeRenewal()` catch blocks emitted a hard-coded `"Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server."`. These catches fire for **any** exception/throwable (finalize failure, cert-store write error, etc.), so that line frequently misdirected operators toward a DNS/challenge problem that wasn't the cause.

## Fix
- Append the concise `$e->getMessage()` to the operator-facing `EE::warning` in `check()` and both `executeRenewal()` catches (full detail still logged at `debug`).
- Drop the misleading generic "Challenge Authorization failed…" line from the `executeRenewal()` catches; the now-specific message and the existing "re-run ssl-verify" hint remain.

## Notes
The exception text surfaces at warning level. ACME error strings contain no account-key material or JWS tokens (the ACME server never echoes those); the only incremental disclosure is absolute server paths on filesystem errors, acceptable for operator-run CLI tooling (the pre-existing `EE::debug(print_r($e))` already dumped far more).

## Testing
Manual: trigger a renewal failure (unreachable domain / rate-limit) without `--debug` and confirm the warning now carries the ACME reason.
