### PR TITLE
fix(ssl): block ssl-verify on non-letsencrypt sites

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -1678,6 +1678,11 @@ abstract class EE_Site_Command {
 			$this->site_data = get_site_info( $args );
 		}
 
+		// SSL verification issues a Let's Encrypt cert via ACME, which is meaningless for non-LE certs and would clobber custom/self/inherited ones.
+		if ( 'le' !== $this->site_data['site_ssl'] ) {
+			EE::error( 'SSL verification is only applicable to Let\'s Encrypt certificates.' );
+		}
+
 		if ( ! isset( $this->le_mail ) ) {
 			$this->le_mail = \EE::get_config( 'le-mail' ) ?? \EE::input( 'Enter your mail id: ' );
 		}


### PR DESCRIPTION
## Problem
`ee site ssl-verify` (`ssl_verify()`) had no guard on the site's SSL type. Run on a `custom` / `self` / `inherit` site it would still prompt for a Let's Encrypt email, instantiate the ACME client, run the challenge, and request an LE certificate — which **overwrites the user's custom certificate** if the domain validates, or yields a confusing "Failed to verify SSL" error with a retry hint that can never succeed for a non-LE cert.

## Fix
Guard `ssl_verify()` to error clearly when `site_ssl !== 'le'`. The guard sits after `site_data` is populated (so it covers the user-invoked subcommand) and does **not** affect the internal call from `init_le()` during LE site creation — that path is only reached when `site_ssl === 'le'`, so the guard never fires there.

## Testing
Manual:
1. `ee site create custom.test --type=html --ssl=custom --ssl-key=... --ssl-crt=...`
2. `ee site ssl-verify custom.test` → exits with "SSL verification is only applicable to Let's Encrypt certificates." (no email prompt, no ACME run, certs untouched).
3. Regression: an `--ssl=le` site still verifies/renews as before.
