### PR TITLE
fix(ssl): skip le renewal on alias-domain change for non-le sites

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -610,14 +610,22 @@ abstract class EE_Site_Command {
 		$old_certs = $client->loadDomainCertificates( $all_domains );
 
 		if ( $is_ssl ) {
-			// Update SSL.
-			EE::log( 'Updating and force renewing SSL certificate to accomodated alias domain changes.' );
-			try {
-				$this->ssl_renew( [ $this->site_data['site_url'] ], [ 'force' => true ] );
-			} catch ( \Exception $e ) {
-				EE::warning( 'Certificate could not be issued. Reverting back to original state.' );
-				$this->enable( [ $this->site_data['site_url'] ], [ 'refresh' => 'true' ] );
-				EE::error( $e->getMessage() );
+			// Only Let's Encrypt certs can be reissued by EE to cover the new alias-domain set.
+			if ( 'le' === $this->site_data['site_ssl'] ) {
+				// Update SSL.
+				EE::log( 'Updating and force renewing SSL certificate to accomodated alias domain changes.' );
+				try {
+					$this->ssl_renew( [ $this->site_data['site_url'] ], [ 'force' => true ] );
+				} catch ( \Exception $e ) {
+					EE::warning( 'Certificate could not be issued. Reverting back to original state.' );
+					$this->enable( [ $this->site_data['site_url'] ], [ 'refresh' => 'true' ] );
+					EE::error( $e->getMessage() );
+				}
+			} elseif ( 'custom' === $this->site_data['site_ssl'] ) {
+				EE::warning( 'Custom SSL certificate is not renewed automatically. Please ensure the certificate you provided covers the updated alias-domain set.' );
+			} else {
+				// self-signed certs are wildcard and inherited certs use the parent site's cert; no cert action needed.
+				EE::log( 'No SSL certificate action needed for ' . $this->site_data['site_ssl'] . ' SSL on alias domain change.' );
 			}
 		}
 


### PR DESCRIPTION
## Problem
Adding/removing alias domains on a non-LE SSL site (`custom` / `self` / `inherit`) hard-errored. `update_alias_domains()` unconditionally calls `ssl_renew()` for any SSL-enabled site, and `renew_ssl_cert()` does `EE::error('Only Letsencrypt certificate renewal is supported.')`. Because `EE::error()` exits, the operation aborted **after** docker-compose was regenerated and containers restarted with the new alias config, but **before** the DB was updated — leaving container and DB state inconsistent (and with no revert, since `EE::error` doesn't throw).

## Fix
Only call `ssl_renew()` when `site_ssl === 'le'` (the LE path is unchanged, byte-for-byte). For `custom`, warn that the user must supply a cert covering the new alias set; for `self`/`inherit`, log that no cert action is needed. The alias-domain update now completes for all SSL types.

## Note
With the hard error gone, execution now reaches the existing `revokeCertificates($old_certs)` for non-LE sites. `$old_certs` is loaded from the ACME repository, so it is empty (a no-op) for a normal custom site; in the edge case where stale LE artifacts exist for the same domains, those unused certs are revoked — consistent with the line's "revoke old certificate which will not be used" intent.

## Testing
Manual: create a `--ssl=custom` site, run `ee site update <site> --add-alias-domains=foo.test` → completes with the custom-cert warning (previously: hard error). LE sites still force-renew exactly as before.
