### PR TITLE
fix(ssl): copy and validate custom certs on site update

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -420,6 +420,12 @@ abstract class EE_Site_Command {
 	 * [--wildcard]
 	 * : Enable wildcard SSL on site.
 	 *
+	 * [--ssl-key=<ssl-key-path>]
+	 * : Path to the SSL key file. Required with --ssl=custom.
+	 *
+	 * [--ssl-crt=<ssl-crt-path>]
+	 * : Path to the SSL crt file. Required with --ssl=custom.
+	 *
 	 * [--php=<php-version>]
 	 * : PHP version for site. Currently only supports PHP 5.6, 7.0, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5.
 	 * ---
@@ -470,6 +476,9 @@ abstract class EE_Site_Command {
 	 *
 	 *     # Add self-signed SSL to non-ssl site
 	 *     $ ee site update example.com --ssl=self
+	 *
+	 *     # Add custom SSL to non-ssl site
+	 *     $ ee site update example.com --ssl=custom --ssl-key=/path/to/site.key --ssl-crt=/path/to/site.crt
 	 *
 	 *     # Update PHP version of site.
 	 *     $ ee site update example.com --php=8.0
@@ -937,6 +946,13 @@ abstract class EE_Site_Command {
 			$this->site_data['site_ssl'] = $ssl;
 
 			if ( $ssl ) {
+				// www_ssl_wrapper() skips cert work for custom SSL, so mirror the create
+				// path here: validate the provided key/crt and copy them into the
+				// nginx-proxy certs dir before enabling HTTPS, else the site serves a wrong cert.
+				if ( 'custom' === $ssl ) {
+					$this->validate_site_custom_ssl( get_flag_value( $assoc_args, 'ssl-key' ), get_flag_value( $assoc_args, 'ssl-crt' ) );
+					$this->custom_site_ssl();
+				}
 				$this->www_ssl_wrapper( [ 'nginx' ] );
 			} else {
 				$this->disable_ssl();


### PR DESCRIPTION
## Problem
`ee site update --ssl=custom` set the DB flag and enabled HTTPS but **never copied the certificate files**. `update_ssl()` calls `www_ssl_wrapper()`, which explicitly skips all cert work for `custom`, and the cert-copy helpers (`validate_site_custom_ssl()` / `custom_site_ssl()`) were only invoked from the **create** path. Result: HTTPS turned on with no certs in `nginx-proxy/certs/`, so the site served a wrong/default cert. This is also the path `Cloner.php` recommends after cloning a custom-SSL site, so that guidance led to a broken state too.

## Fix
In `update_ssl()`, when the target type is `custom`, mirror the create path: validate `--ssl-key`/`--ssl-crt` via `validate_site_custom_ssl()` and copy them via `custom_site_ssl()` **before** `www_ssl_wrapper()`. Also documents the `--ssl-key`/`--ssl-crt` flags and adds an example. Re-running this command is now also the way to replace an expiring custom cert.

Missing/invalid `--ssl-key`/`--ssl-crt` fails fast (inside the existing try/catch, before `$site->save()`), so there is no partial DB-vs-cert state.

## Known limitation
If the post-copy bring-up (`www_ssl_wrapper`) throws, the copied cert files are left in place (no rollback); re-running the command overwrites them. The create path's `catch_clean` unwind is not mirrored here — a follow-up could unify the two cert paths.

## Testing
Manual: create a non-SSL site, generate a self-signed key/crt, run `ee site update <site> --ssl=custom --ssl-key=... --ssl-crt=...`, and assert `nginx-proxy/certs/<site>.key|.crt` exist and the served cert matches.
