### PR TITLE
fix(migration): don't reclassify custom ssl sites as letsencrypt

### DIFF
--- a/migrations/db/20250927101545_site-command_fix_ssl_flag_for_existing_le_certs.php
+++ b/migrations/db/20250927101545_site-command_fix_ssl_flag_for_existing_le_certs.php
@@ -51,7 +51,8 @@ class FixSslFlagForExistingLeCerts extends Base {
 			}
 
 			if ( $crt_exists && $key_exists && $chain_exists ) {
-				if ( empty( $db_ssl ) || $db_ssl !== 'le' ) {
+				// Only repair sites with an unset SSL flag; never override an explicit custom/self/inherit (or le) choice.
+				if ( empty( $db_ssl ) ) {
 					// Check if the cert is a valid Let's Encrypt cert using CertificateParser
 					try {
 						$crt_pem = file_get_contents( $crt );


### PR DESCRIPTION
## Problem
The `20250927101545_..._fix_ssl_flag_for_existing_le_certs` migration auto-sets `site_ssl = 'le'` for sites that have LE-looking cert files on disk and a Let's Encrypt issuer. Its gate `empty( $db_ssl ) || $db_ssl !== 'le'` matches **any** non-`le` site — including ones explicitly created with `--ssl=custom` (also `self`/`inherit`). A custom site using a Let's Encrypt-issued cert (with a `.chain.pem` present) would be silently reclassified to `le` and pulled into automatic LE renewal that can overwrite or break the user's certificate.

## Fix
Narrow the gate to `empty( $db_ssl )` — repair only sites whose SSL flag is genuinely unset (the migration's intent). Explicit `custom`/`self`/`inherit` (and `le`) choices are never overridden. `down()` remains a no-op (forward-only). The boolean change preserves the un-flagged-LE repair case and removes only the unwanted override (the old `|| $db_ssl !== 'le'` half was already redundant for the `le` case).

## Note
A site whose flag was explicitly set to a *wrong* non-empty value will no longer be auto-corrected — an intentional, conservative trade-off: a data migration should not override an explicit user choice.
