### PR TITLE
fix(ssl): deploy nginx-proxy certs atomically with checked copies

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -502,9 +502,34 @@ class Site_Letsencrypt {
 		$crt_dest_file   = EE_ROOT_DIR . '/services/nginx-proxy/certs/' . $domain . '.crt';
 		$chain_dest_file = EE_ROOT_DIR . '/services/nginx-proxy/certs/' . $domain . '.chain.pem';
 
-		copy( $key_source_file, $key_dest_file );
-		copy( $crt_source_file, $crt_dest_file );
-		copy( $chain_source_file, $chain_dest_file );
+		// Copy each source to a temp file in the destination dir, then rename into place. Each rename()
+		// is atomic per-file on the same filesystem, so a failed copy (disk full, permissions, crash)
+		// can never leave a half-written live cert/key. The renames are not collectively atomic and we do
+		// not roll back an already-renamed file; on any failure we clean up the temps and throw.
+		$copy_map = [
+			$key_source_file   => $key_dest_file,
+			$crt_source_file   => $crt_dest_file,
+			$chain_source_file => $chain_dest_file,
+		];
+
+		// $temp_files maps temp path => final destination path.
+		$temp_files = [];
+		foreach ( $copy_map as $source => $dest ) {
+			$temp = $dest . '.tmp';
+			if ( ! copy( $source, $temp ) ) {
+				// Include the current temp: a failed copy may still have created a partial file.
+				array_map( 'unlink', array_filter( array_merge( array_keys( $temp_files ), [ $temp ] ), 'file_exists' ) );
+				throw new \Exception( sprintf( 'Failed to copy certificate file %s to %s.', $source, $temp ) );
+			}
+			$temp_files[ $temp ] = $dest;
+		}
+
+		foreach ( $temp_files as $temp => $dest ) {
+			if ( ! rename( $temp, $dest ) ) {
+				array_map( 'unlink', array_filter( array_keys( $temp_files ), 'file_exists' ) );
+				throw new \Exception( sprintf( 'Failed to move certificate file %s to %s.', $temp, $dest ) );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem
`moveCertsToNginxProxy()` deployed the freshly-issued cert with three sequential bare `copy()` calls (key, crt, chain) into `services/nginx-proxy/certs/`, ignoring every return value and with no temp-file + rename. A failure between copies (disk full, permissions, crash) left nginx-proxy pointing at a **mismatched key/cert pair**. This runs on both first issuance and renewal (the unattended cron path).

## Fix
Copy each source to a temp file in the destination directory (checking `copy()`), then `rename()` each into place (checking `rename()`). `rename()` is atomic on the same filesystem, so a failed copy can no longer leave a half-written live key/cert. On any failure the temp files are cleaned up and an exception is thrown, rather than silently leaving a partial deploy.

## Notes
- The three renames are each atomic per-file but not *collectively* atomic; the code does not roll back an already-renamed file (a same-filesystem rename failing after a prior success is near-impossible). The comment states this precisely.
- The method stays `void` and throws on failure: `executeRenewal()` already wraps the call in try/catch (surfaces as a renewal warning); on first issuance the exception propagates as a loud failure — preferable to the previous silent broken-cert outcome.

## Testing
Manual (needs the EE + Docker harness): issue/renew a cert and confirm `.key/.crt/.chain.pem` deploy together with no `.tmp` leftovers; make the certs dir unwritable to force a failure and confirm it errors without leaving a mismatched pair.
