### PR TITLE
fix(ssl): validate custom certificate and key before install

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -2250,10 +2250,47 @@ abstract class EE_Site_Command {
 		}
 
 		if ( $this->fs->exists( $ssl_key ) && $this->fs->exists( $ssl_crt ) ) {
+			// Validate cert contents before storing paths, else a malformed/mismatched pair silently breaks nginx-proxy on reload.
+			$this->assert_valid_cert_key_pair( file_get_contents( $ssl_crt ), file_get_contents( $ssl_key ) );
+
 			$this->site_data['ssl_key'] = realpath( $ssl_key );
 			$this->site_data['ssl_crt'] = realpath( $ssl_crt );
 		} else {
 			throw new \Exception( 'ssl-key OR ssl-crt path does not exist' );
+		}
+	}
+
+	/**
+	 * Assert that a PEM certificate and private key are valid, matching and not expired.
+	 *
+	 * @param string $crt_contents Certificate file contents (PEM).
+	 * @param string $key_contents Private key file contents (PEM).
+	 */
+	protected function assert_valid_cert_key_pair( $crt_contents, $key_contents ) {
+
+		$cert_info = openssl_x509_parse( $crt_contents );
+		if ( false === $cert_info ) {
+			EE::error( 'The supplied --ssl-crt is not a valid/parseable certificate.' );
+		}
+
+		if ( false === openssl_pkey_get_private( $key_contents ) ) {
+			EE::error( 'The supplied --ssl-key is not a valid private key.' );
+		}
+
+		if ( ! openssl_x509_check_private_key( $crt_contents, $key_contents ) ) {
+			EE::error( 'The supplied certificate and private key do not match.' );
+		}
+
+		// Warn (but allow) on an expired or soon-to-expire cert: clone/restore may legitimately re-supply an existing expired cert, so don't block.
+		if ( isset( $cert_info['validTo_time_t'] ) ) {
+			$now              = time();
+			$expiry_threshold = 30 * 24 * 60 * 60; // 30 days in seconds.
+
+			if ( $cert_info['validTo_time_t'] < $now ) {
+				EE::warning( sprintf( 'The supplied certificate expired on %s.', date( 'Y-m-d', $cert_info['validTo_time_t'] ) ) );
+			} elseif ( $cert_info['validTo_time_t'] - $now < $expiry_threshold ) {
+				EE::warning( sprintf( 'The supplied certificate expires on %s (within 30 days).', date( 'Y-m-d', $cert_info['validTo_time_t'] ) ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem
`validate_site_custom_ssl()` only checked that the `--ssl-key`/`--ssl-crt` files exist; `custom_site_ssl()` then copied them into `services/nginx-proxy/certs/` with no validation. A malformed PEM, or a certificate and key that don't match, silently breaks nginx-proxy on the next reload.

## Fix
Add `assert_valid_cert_key_pair()` (called from `validate_site_custom_ssl()` before the paths are stored): parse the certificate (`openssl_x509_parse`), parse the key (`openssl_pkey_get_private`), and verify they match (`openssl_x509_check_private_key`). An unparseable certificate, an invalid key, or a key/cert mismatch are hard errors. An expired or near-expiry (< 30 days) certificate is a loud **warning** (not a block), so legitimate clone/restore flows that re-supply an existing certificate still proceed.

## Testing
Manual: mismatched key/crt → error; malformed PEM → error; expired cert → warning (proceeds); valid matching pair → installs. The validation helper is pure and unit-testable.
