### PR TITLE
fix(ssl): detect and rebuild stale ACME orders on verify/retry

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -360,6 +360,32 @@ class Site_Letsencrypt {
 			\EE::debug( sprintf( 'Loading the authorization token for domains %s ...', implode( ', ', $domains ) ) );
 		}
 
+		// Self-heal stale orders: LE expires/deactivates a pending order/authorization (~7 days), after which the
+		// stored order is dead and validation fails forever. Only init_le() calls authorize(), so on a retry via
+		// ssl-verify we must rebuild the order here. Pending/valid authorizations are still live, so the common
+		// "DNS not ready yet, retry later" case is left untouched and never triggers a rebuild.
+		if ( $order && $this->isCertificateOrderStale( $order, $domains ) ) {
+			\EE::debug( 'Stored ACME order is stale/expired; requesting a fresh order.' );
+			$this->repository->removeCertificateOrder( $domains );
+			$this->revokeAuthorizationChallenges( $domains ); // best-effort: clears stale challenge files.
+			if ( ! $this->authorize( $domains, $wildcard, $preferred_challenge ) ) {
+				return false;
+			}
+
+			// Manual DNS-01 rebuild issues a brand-new TXT token that authorize() only printed above; the old record
+			// is now wrong, so validating immediately would fail confusingly. Stop and let the user publish it first.
+			// (HTTP-01 wrote the token file + reloaded nginx, and Cloudflare DNS publishes automatically — both fall through.)
+			if ( $is_solver_dns && empty( get_config_value( 'cloudflare-api-key' ) ) ) {
+				$primary_domain = str_replace( '*.', '', $domains[0] );
+				\EE::warning( "The previous ACME order for $primary_domain had expired. A fresh DNS-01 challenge was issued and its new TXT record is printed above." );
+				\EE::log( "Publish the new TXT record, then re-run: ee site ssl-verify $primary_domain" );
+
+				return false;
+			}
+
+			$order = $this->repository->loadCertificateOrder( $domains );
+		}
+
 		$authorizationChallengeToCleanup = [];
 		foreach ( $domains as $domain ) {
 			if ( $order ) {
@@ -429,6 +455,59 @@ class Site_Letsencrypt {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Determine whether a stored ACME order can no longer be used to validate the given domains.
+	 *
+	 * An order is stale when LE has expired/deactivated/revoked/invalidated its authorizations (which it does for
+	 * orders left pending for ~7 days) or when it lacks a challenge for a requested domain (e.g. the SAN set changed).
+	 * `pending` and `valid` authorizations are still live and are NOT stale, so an in-progress retry is preserved.
+	 *
+	 * @param CertificateOrder $order   The loaded order to inspect.
+	 * @param array            $domains Requested domains for this order.
+	 *
+	 * @return bool True if the order should be discarded and rebuilt.
+	 */
+	private function isCertificateOrderStale( $order, array $domains ) {
+		foreach ( $domains as $domain ) {
+			try {
+				// Throws if the order has no challenge for this requested domain (e.g. SAN set changed).
+				$authorizationChallenges = $order->getAuthorizationChallenges( $domain );
+			} catch ( \Exception $e ) {
+				\EE::debug( sprintf( 'No authorization challenge in stored order for %s: %s', $domain, $e->getMessage() ) );
+
+				return true;
+			}
+
+			// All challenges of one authorization share its status, so reloading the first is enough; the break below
+			// avoids redundant ACME round-trips (and a wider transient-error window) for the remaining challenges.
+			foreach ( $authorizationChallenges as $challenge ) {
+				try {
+					// reloadAuthorization refetches live status from LE.
+					$challenge = $this->client->reloadAuthorization( $challenge );
+				} catch ( \Throwable $e ) {
+					// Treat a failed reload as inconclusive, NOT stale: it also throws on transient LE errors (5xx,
+					// 429, timeouts), and tearing down a healthy in-flight order on a blip would hit the rate-limited
+					// newOrder endpoint. Trade-off: a fully-purged authz (404) is not auto-rebuilt; the common expiry
+					// case reloads successfully with an `expired` status and is handled below.
+					\EE::debug( sprintf( 'Reloading authorization for %s failed (treating as inconclusive, keeping order): %s', $domain, $e->getMessage() ) );
+
+					return false;
+				}
+
+				// pending/valid are live; anything else (expired/deactivated/revoked/invalid) is unusable.
+				if ( ! in_array( $challenge->getStatus(), [ 'pending', 'valid' ], true ) ) {
+					\EE::debug( sprintf( 'Authorization for %s has stale status "%s".', $domain, $challenge->getStatus() ) );
+
+					return true;
+				}
+
+				break;
+			}
+		}
+
+		return false;
 	}
 
 	public function request( $domain, $altNames = [], $email, $force = false ) {


### PR DESCRIPTION
## Problem
A one-time DNS hiccup or timeout could permanently break SSL for a site. On issuance failure the ACME order/challenge files are left on disk; the user fixes DNS and re-runs `ee site ssl-verify` → `check()` blindly reloads the on-disk order and reuses it. Within ~7 days while the order is still `pending` this works (and is preserved). But once Let's Encrypt expires the pending order, the reloaded order is dead, validation fails forever, and the site shows a generic "Cannot validate challenge" on every retry — because the retry path never requests a fresh order (only `init_le` calls `authorize()`).

## Fix
`check()` now detects a stale stored order and rebuilds it before validating. `isCertificateOrderStale()` reloads each domain's authorization from Let's Encrypt and treats the order as stale when an authorization's live status is not `pending`/`valid` (expired/deactivated/revoked/invalid), or when the stored order doesn't cover a requested domain. On staleness it removes the dead order + challenge, calls `authorize()` for a fresh order, and continues.

Safeguards (validated by review):
- A **transient** Let's Encrypt error (5xx/429/timeout) during the reload is treated as inconclusive — the order is preserved and the run fails gracefully for a later retry — rather than destroying a healthy in-flight order and burning a rate-limited `newOrder` slot.
- The creation path (fresh order) and the normal "DNS not ready yet, retry later" path (pending order) do **not** trigger a rebuild — behavior there is unchanged.
- For manual DNS-01 (no Cloudflare API key) a rebuild issues a new TXT value, so the command warns the user to publish the new record and re-run, instead of failing validation confusingly. HTTP-01 and Cloudflare-automated DNS continue to validation as before.

## Known limitation
If Let's Encrypt fully purges an expired authorization (the reload returns 404 rather than status `expired`), the order is not auto-rebuilt — the conservative choice that avoids the transient-error regression above. The common expiry case (status `expired` on a successful reload) is handled.

## Testing
Manual (needs the ACME/Docker harness): simulate a stale order (let a pending order expire, or deactivate the authorization server-side), point DNS correctly, then run `ee site ssl-verify` → it requests a fresh order instead of looping. Negative test: with the order still `pending`, confirm no rebuild and the normal retry path.
