### PR TITLE
fix(proxy): only reload nginx-proxy when its config test passes

### DIFF
--- a/src/helper/site-utils.php
+++ b/src/helper/site-utils.php
@@ -555,11 +555,18 @@ function configure_postfix( $site_url, $site_fs_path ) {
  */
 function reload_global_nginx_proxy() {
 
-	if ( \EE::launch( sprintf( 'docker exec %s sh -c "nginx -t"', EE_PROXY_TYPE ) ) ) {
-		return \EE::launch( sprintf( 'docker exec %s sh -c "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload"', EE_PROXY_TYPE ) );
+	// Regenerate default.conf first so `nginx -t` validates the config that will actually be served.
+	\EE::launch( sprintf( 'docker exec %s sh -c "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf"', EE_PROXY_TYPE ) );
+
+	// `EE::launch()` returns a ProcessRun object (truthy), so gate on the exit code to avoid reloading a broken config.
+	$test = \EE::launch( sprintf( 'docker exec %s sh -c "nginx -t"', EE_PROXY_TYPE ) );
+	if ( 0 !== $test->return_code ) {
+		\EE::warning( 'nginx config test failed, skipping reload of ' . EE_PROXY_TYPE . ":\n" . $test->stderr );
+
+		return false;
 	}
 
-	return false;
+	return \EE::launch( sprintf( 'docker exec %s sh -c "/usr/sbin/nginx -s reload"', EE_PROXY_TYPE ) );
 }
 
 /**


### PR DESCRIPTION
## Problem
`reload_global_nginx_proxy()` gated the proxy reload on `if ( \EE::launch( '... nginx -t' ) )`. But `EE::launch()` defaults to returning a **`ProcessRun` object** (not an exit code), and every object is truthy in PHP — so the `if` was **always true** and the config was regenerated and reloaded regardless of whether `nginx -t` passed. A broken nginx config (e.g. from a half-written cert pair or a malformed vhost rule) was therefore reloaded and persisted; the shared proxy then fails to start on its next restart, taking down every site behind it.

Compounding bug: `nginx -t` also ran *before* the docker-gen regeneration, so it validated the pre-regeneration config rather than the `default.conf` that actually gets served.

## Fix
Regenerate `default.conf` first, then capture the `nginx -t` `ProcessRun` and gate on `0 === $test->return_code`. On failure, warn with the test output and skip the reload (return `false`); on success, reload. This mirrors the working `nginx -t && nginx -s reload` pattern already used elsewhere in the codebase.

## Notes
- Scope is this function's internal gate. The ~15 external callers that ignore the return value are unchanged; a skipped reload now returns `false` and emits an `EE::warning`, but wiring callers to react to that is a separate change.

## Testing
Manual (needs the EE + Docker harness): introduce an invalid proxy config (bad cert/vhost), trigger a reload, and confirm it warns and does NOT reload/persist the broken config; with a valid config, confirm normal regenerate + reload.
