### PR TITLE
fix(ssl): prevent shell injection via site name in self-signed cert generation

### DIFF
--- a/src/helper/Site_Self_Signed.php
+++ b/src/helper/Site_Self_Signed.php
@@ -90,8 +90,10 @@ class Site_Self_signed {
 
 		$this->build_certificate_conf( $root_conf, 'EasyEngine' );
 
-		EE::exec( sprintf( 'openssl genrsa -des3 -passout pass:%s -out %s 2048', $this->password, $this->root_key ) );
-		EE::exec( sprintf( 'openssl req -x509 -new -nodes -key %s -sha256 -days 36500 -passin pass:%s -out %s -config %s', $this->root_key, $this->password, $this->root_pem, $root_conf ) );
+		// Escape every interpolated value: these strings run through /bin/sh -c, so an
+		// unescaped password (or path) could inject an attacker subshell as root.
+		EE::exec( sprintf( 'openssl genrsa -des3 -passout pass:%s -out %s 2048', escapeshellarg( $this->password ), escapeshellarg( $this->root_key ) ) );
+		EE::exec( sprintf( 'openssl req -x509 -new -nodes -key %s -sha256 -days 36500 -passin pass:%s -out %s -config %s', escapeshellarg( $this->root_key ), escapeshellarg( $this->password ), escapeshellarg( $this->root_pem ), escapeshellarg( $root_conf ) ) );
 
 		$this->trust_certificate( $this->root_pem );
 
@@ -133,10 +135,12 @@ class Site_Self_signed {
 	 */
 	private function generate_certificate( $key_path, $crt_path, $csr_path, $conf_path, $v3_path ) {
 
-		EE::exec( sprintf( 'openssl req -new -sha256 -nodes -passout pass:%s -out %s -newkey rsa:2048 -keyout %s -config %s', $this->password, $csr_path, $key_path, $conf_path ) );
+		// Paths here derive from the (unvalidated) site name and run through /bin/sh -c,
+		// so escape every interpolated value to prevent shell injection via the site name.
+		EE::exec( sprintf( 'openssl req -new -sha256 -nodes -passout pass:%s -out %s -newkey rsa:2048 -keyout %s -config %s', escapeshellarg( $this->password ), escapeshellarg( $csr_path ), escapeshellarg( $key_path ), escapeshellarg( $conf_path ) ) );
 
-		$serial_string = $this->fs->exists( $this->root_srl ) ? sprintf( '-CAserial %s', $this->root_srl ) : sprintf( '-CAcreateserial -CAserial %s', $this->root_srl );
-		EE::exec( sprintf( 'openssl x509 -req -in %s -CA %s -CAkey %s %s -passin pass:%s -out %s -days 36500 -sha256 -extfile %s', $csr_path, $this->root_pem, $this->root_key, $serial_string, $this->password, $crt_path, $v3_path ) );
+		$serial_string = $this->fs->exists( $this->root_srl ) ? sprintf( '-CAserial %s', escapeshellarg( $this->root_srl ) ) : sprintf( '-CAcreateserial -CAserial %s', escapeshellarg( $this->root_srl ) );
+		EE::exec( sprintf( 'openssl x509 -req -in %s -CA %s -CAkey %s %s -passin pass:%s -out %s -days 36500 -sha256 -extfile %s', escapeshellarg( $csr_path ), escapeshellarg( $this->root_pem ), escapeshellarg( $this->root_key ), $serial_string, escapeshellarg( $this->password ), escapeshellarg( $crt_path ), escapeshellarg( $v3_path ) ) );
 	}
 
 	/**
@@ -151,7 +155,7 @@ class Site_Self_signed {
 		if ( IS_DARWIN ) {
 			EE::log( 'You may need to enter password once for adding root certificate as trusted on your system.' );
 			EE::exec( sprintf(
-				'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s', $crt_path
+				'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %s', escapeshellarg( $crt_path )
 			) );
 		} else {
 			$cert_path = '/usr/local/share/ca-certificates';


### PR DESCRIPTION
## Problem (security — command injection / root RCE)
`Site_Self_Signed.php` builds `openssl` commands with `sprintf` and runs them via `EE::exec` → `proc_open` → `/bin/sh -c`. The site name (and the file paths derived from it) were interpolated into those command strings **without `escapeshellarg`**, and the site name is not charset-validated anywhere upstream (`name_checks_and_updates` only lowercases / appends `.test`; ee-core has no validation either). So a name like `x$(touch /tmp/PWNED).com` passed to `ee site create … --ssl=self` would execute an attacker subshell as the EasyEngine (root) user. Confirmed reachable end-to-end.

## Fix
Wrap every user- and config-derived value interpolated into the `openssl` shell commands with `escapeshellarg()` — the site-name-derived CSR/key/cert/conf paths, the CA key/pem/serial paths, and the CA password. `escapeshellarg` only changes shell parsing, so `openssl` still receives the literal `-subj`/SAN/`pass:`/path values — no functional change, but shell metacharacters can no longer break out. The class no longer trusts its input (defense-in-depth), independent of any upstream validation.

`$serial_string` is already escaped where it is built, so it is interpolated as-is at the final call to avoid double-quoting `-CAserial`.

## Out of scope
The CA password is still passed as a `pass:` argument and logged in cleartext (the `$obfuscate` argument to `EE::exec` is unused) — tracked separately as audit finding A-04.

## Testing
Manual: `ee site create 'x$(touch /tmp/INJECT).com' --ssl=self` (or with backticks) must NOT create `/tmp/INJECT` and must treat the metacharacters as literal; a normal `--ssl=self` site still generates its self-signed cert correctly.
