### PR TITLE
fix(ssl): validate le-mail before letsencrypt registration

### DIFF
--- a/src/helper/class-ee-site.php
+++ b/src/helper/class-ee-site.php
@@ -1540,7 +1540,7 @@ abstract class EE_Site_Command {
 		$this->site_data['site_fs_path']      = $site_fs_path;
 		$this->site_data['site_ssl_wildcard'] = $wildcard;
 		$client                               = new Site_Letsencrypt();
-		$this->le_mail                        = \EE::get_runner()->config['le-mail'] ?? \EE::input( 'Enter your mail id: ' );
+		$this->le_mail                        = $this->get_validated_le_mail( \EE::get_runner()->config['le-mail'] ?? null );
 		\EE::get_runner()->ensure_present_in_config( 'le-mail', $this->le_mail );
 		if ( ! $client->register( $this->le_mail ) ) {
 			$this->site_data['site_ssl'] = null;
@@ -1575,6 +1575,30 @@ abstract class EE_Site_Command {
 				return;
 			}
 		}
+	}
+
+	/**
+	 * Resolves and validates the Let's Encrypt account email.
+	 *
+	 * `??` only guards null/unset, so an empty/garbage le-mail (e.g. an empty STDIN
+	 * read during non-interactive cron runs) used to slip through to ACME and fail
+	 * with an opaque error. Validate here so callers always get a real email.
+	 *
+	 * @param string|null $config_mail Email resolved from config by the caller, if any.
+	 *
+	 * @return string A non-empty, valid email address.
+	 */
+	private function get_validated_le_mail( $config_mail = null ) {
+		$mail = $config_mail;
+		if ( empty( $mail ) || ! filter_var( $mail, FILTER_VALIDATE_EMAIL ) ) {
+			// One re-prompt for interactive users; on non-interactive runs STDIN is empty and this stays empty.
+			$mail = \EE::input( 'Enter your mail id: ' );
+		}
+		if ( empty( $mail ) || ! filter_var( $mail, FILTER_VALIDATE_EMAIL ) ) {
+			\EE::error( 'A valid Let\'s Encrypt email is required. Set it with `ee config set le-mail <email>`.' );
+		}
+
+		return $mail;
 	}
 
 	/**
@@ -1679,7 +1703,7 @@ abstract class EE_Site_Command {
 		}
 
 		if ( ! isset( $this->le_mail ) ) {
-			$this->le_mail = \EE::get_config( 'le-mail' ) ?? \EE::input( 'Enter your mail id: ' );
+			$this->le_mail = $this->get_validated_le_mail( \EE::get_config( 'le-mail' ) );
 		}
 
 		$force         = \EE\Utils\get_flag_value( $assoc_args, 'force' );
@@ -1944,10 +1968,6 @@ abstract class EE_Site_Command {
 
 		EE::log( 'Starting SSL cert renewal' );
 
-		if ( ! isset( $this->le_mail ) ) {
-			$this->le_mail = EE::get_config( 'le-mail' ) ?? EE::input( 'Enter your mail id: ' );
-		}
-
 		$force = get_flag_value( $assoc_args, 'force', false );
 		$all   = get_flag_value( $assoc_args, 'all', false );
 
@@ -1997,6 +2017,11 @@ abstract class EE_Site_Command {
 
 		if ( 'le' !== $this->site_data['site_ssl'] ) {
 			EE::error( 'Only Letsencrypt certificate renewal is supported.' );
+		}
+
+		// Resolve le-mail only after confirming the site is LE, so non-LE sites hit the site-type error first.
+		if ( ! isset( $this->le_mail ) ) {
+			$this->le_mail = $this->get_validated_le_mail( EE::get_config( 'le-mail' ) );
 		}
 
 		$client              = new Site_Letsencrypt();


### PR DESCRIPTION
## Problem
The Let's Encrypt account email (`le-mail`) was resolved with a `??` fallback that only guards null/unset — an **empty string** passed straight through to ACME `register()`/`request()`, producing a generic, confusing ACME failure. This affected `init_le`, `ssl_verify`, and `ssl_renew`.

## Fix
Add a shared `get_validated_le_mail()` helper: resolve from config (or prompt interactively), validate non-empty + `filter_var( …, FILTER_VALIDATE_EMAIL )`, and hard-error with a clear message (`Set it with \`ee config set le-mail <email>\`.`) when it can't be resolved (e.g. non-interactive cron with no le-mail set). All three sites route through it.

In the renewal path the email is resolved **after** the `'le'`/`'inherit'` site-type guard in `renew_ssl_cert()`, so a non-LE single-site `ssl-renew` still gets the accurate "Only Letsencrypt certificate renewal is supported." error rather than an email error.

## Testing
Manual: with `le-mail` unset/garbage, a non-interactive LE issuance/renew now exits cleanly with the "valid email required" message instead of an opaque ACME error; a valid `le-mail` proceeds as before; a non-LE `ssl-renew` still reports the site-type error.
