### PR TITLE
fix(ssl): honor updated le-mail on certificate renewal

### DIFF
--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -691,6 +691,9 @@ class Site_Letsencrypt {
 		if ( $this->repository->hasDomainDistinguishedName( $domain ) ) {
 			$original = $this->repository->loadDomainDistinguishedName( $domain );
 
+			// Honor an updated le-mail on renewal; fall back to stored email only when none is passed.
+			$email_address = ! empty( $email ) ? $email : $original->getEmailAddress();
+
 			$distinguishedName = new DistinguishedName(
 				$domain,
 				$original->getCountryName(),
@@ -698,7 +701,7 @@ class Site_Letsencrypt {
 				$original->getLocalityName(),
 				$original->getOrganizationName(),
 				$original->getOrganizationalUnitName(),
-				$original->getEmailAddress(),
+				$email_address,
 				$alternativeNames
 			);
 		} else {


### PR DESCRIPTION
## Problem
On renewal, `getOrCreateDistinguishedName()` rebuilt the CSR's distinguished name using the **stored** email (from first issuance) and ignored the `le-mail` value passed in. So changing `le-mail` never took effect on subsequent certificates — every renewal CSR kept the original address. (The SAN list already updated correctly; only the email was sticky.)

## Fix
When a stored distinguished name exists, use the passed `$email` if it is non-empty, falling back to the stored email only when none is provided. The updated DN is persisted as before, so the new email sticks for future renewals. All other DN fields and the SAN list are unchanged.

## Testing
Manual: change `le-mail`, trigger a renewal → the CSR carries the new email; with an empty `le-mail`, the DN falls back to the stored address.
