### PR TITLE
feat(ssl): add inter-site jitter and clear rate-limit messaging to ssl-renew

### DIFF
--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -104,6 +104,8 @@ class Site_Command {
 		} elseif ( in_array( reset( $args ), [ 'ssl-renew' ], true ) && array_key_exists( 'all', $assoc_args ) ) {
 			$sites = Site::all();
 			unset( $assoc_args['all'] );
+			// Spread per-site dispatches over time to avoid bursting against Let's Encrypt rate limits.
+			$dispatched = false;
 			foreach ( $sites as $site ) {
 				$type     = $site->site_type;
 				$args     = [ 'site', 'ssl-renew', $site->site_url ];
@@ -125,11 +127,17 @@ class Site_Command {
 					continue;
 				}
 
+				// Jitter between sites only (not before the first / after the last) to smooth burst load on the LE API.
+				if ( $dispatched ) {
+					sleep( random_int( 1, 5 ) );
+				}
+
 				$command      = EE::get_root_command();
 				$leaf_command = CommandFactory::create( 'site', $callback, $command );
 				$command->add_subcommand( 'site', $leaf_command );
 
 				EE::run_command( $args, $assoc_args );
+				$dispatched = true;
 			}
 			die;
 		} else {

--- a/src/helper/Site_Letsencrypt.php
+++ b/src/helper/Site_Letsencrypt.php
@@ -16,6 +16,7 @@ use AcmePhp\Core\Challenge\Http\SimpleHttpSolver;
 use AcmePhp\Core\Challenge\WaitingValidator;
 use AcmePhp\Core\Exception\Protocol\ChallengeNotSupportedException;
 use AcmePhp\Core\Exception\Protocol\CertificateRevocationException;
+use AcmePhp\Core\Exception\Server\RateLimitedServerException;
 use AcmePhp\Core\Protocol\AuthorizationChallenge;
 use AcmePhp\Core\Protocol\ResourcesDirectory;
 use AcmePhp\Core\Protocol\RevocationReason;
@@ -208,7 +209,12 @@ class Site_Letsencrypt {
 		try {
 			$order = $this->client->requestOrder( $domains );
 		} catch ( \Exception $e ) {
-			\EE::warning( 'It seems you\'re in local environment or using non-public domain, please check logs. Skipping letsencrypt.' );
+			// A rate-limit is a distinct failure from a non-public domain; emit a clear, actionable message for it.
+			if ( $this->is_rate_limit_exception( $e ) ) {
+				\EE::warning( 'Let\'s Encrypt rate limit hit for: ' . implode( ', ', $domains ) . '. Please wait before retrying. Ref: https://letsencrypt.org/docs/rate-limits/' );
+			} else {
+				\EE::warning( 'It seems you\'re in local environment or using non-public domain, please check logs. Skipping letsencrypt.' );
+			}
 			\EE::log( 'You can fix the issue and re-run: ee site ssl-verify ' . $domains[0] );
 
 			return false;
@@ -569,6 +575,26 @@ class Site_Letsencrypt {
 	}
 
 	/**
+	 * Whether the given exception represents a Let's Encrypt rate-limit response.
+	 *
+	 * Matches the acmephp RateLimitedServerException as well as the 'rateLimited' ACME error
+	 * type / HTTP 429 surfaced in the message, so callers can show rate-limit-specific guidance.
+	 *
+	 * @param \Throwable $e
+	 *
+	 * @return bool
+	 */
+	private function is_rate_limit_exception( $e ) {
+		if ( $e instanceof RateLimitedServerException ) {
+			return true;
+		}
+
+		$message = strtolower( $e->getMessage() );
+
+		return ( false !== strpos( $message, 'ratelimited' ) || false !== strpos( $message, 'too many' ) );
+	}
+
+	/**
 	 * Renew a given domain certificate.
 	 *
 	 * @param string $domain
@@ -644,7 +670,12 @@ class Site_Letsencrypt {
 			\EE::warning( 'A critical error occured during certificate renewal' );
 			\EE::debug( print_r( $e, true ) );
 
-			\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
+			// A rate-limit is not a misconfigured-domain failure; point the user to the LE rate-limit docs instead.
+			if ( $this->is_rate_limit_exception( $e ) ) {
+				\EE::warning( 'Let\'s Encrypt rate limit hit for: ' . $domain . '. Please wait before retrying. Ref: https://letsencrypt.org/docs/rate-limits/' );
+			} else {
+				\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
+			}
 			\EE::log( 'You can fix the issue and re-run: ee site ssl-verify ' . $domains[0] );
 
 			return false;
@@ -652,7 +683,12 @@ class Site_Letsencrypt {
 			\EE::warning( 'A critical error occured during certificate renewal' );
 			\EE::debug( print_r( $e, true ) );
 
-			\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
+			// A rate-limit is not a misconfigured-domain failure; point the user to the LE rate-limit docs instead.
+			if ( $this->is_rate_limit_exception( $e ) ) {
+				\EE::warning( 'Let\'s Encrypt rate limit hit for: ' . $domain . '. Please wait before retrying. Ref: https://letsencrypt.org/docs/rate-limits/' );
+			} else {
+				\EE::warning( 'Challenge Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
+			}
 			\EE::log( 'You can fix the issue and re-run: ee site ssl-verify ' . $domains[0] );
 
 			return false;


### PR DESCRIPTION
## Problem
`ssl-renew --all` fires per-site ACME operations back-to-back with no spacing, and on a Let's Encrypt rate limit `authorize()` shows a misleading "you're in a local environment or using a non-public domain" message instead of saying it's a rate limit.

## Fix
- **Inter-site jitter:** a short `sleep( random_int( 1, 5 ) )` between per-site dispatches in the `--all` loop (none before the first or after the last; skipped sites don't count), to avoid bursting against Let's Encrypt's new-order/burst limits.
- **Clear rate-limit messaging:** a helper detects the rate-limit case — authoritatively via `RateLimitedServerException`, plus `ratelimited`/`too many` message fallbacks — and, in `authorize()` and both `executeRenewal()` catches, emits a specific "Let's Encrypt rate limit reached, wait before retrying" message (with the rate-limits docs link) instead of the misleading default.

`ssl-renew --all` already fails soft per site (a rate-limited site returns false and the batch continues); this makes the spacing gentler and the failure legible.

## Out of scope (follow-ups)
A fully failure-resilient `--all` with automatic backoff-and-retry, and removing the dead `if ( $all )` branch in `ssl_renew()`, are larger changes left for later.

## Note for merge
This edits `executeRenewal()`'s catch blocks, which #486 also edits — whichever merges second will need a small rebase to reconcile.

## Testing
Manual: `ssl-renew --all` across several sites spaces requests by 1–5s; a rate-limited renewal reports a clear rate-limit message + docs link rather than the "local environment" warning.
